### PR TITLE
fix: default UART on non-USB targets and improve flash chip detection

### DIFF
--- a/docs-site/getting-started.html
+++ b/docs-site/getting-started.html
@@ -98,6 +98,7 @@ bash &lt;(curl -fsSL https://raw.githubusercontent.com/tnm/zclaw/main/scripts/bo
             <li>Enter WiFi SSID, LLM provider, and model. Use API key for Anthropic/OpenAI/OpenRouter, or API URL for Ollama. Optional Telegram fields can be filled now or later.</li>
             <li>Reboot and inspect logs with <code>./scripts/monitor.sh</code>.</li>
           </ol>
+          <p class="inline-note">ESP32-WROOM/ESP32 DevKit boards run target <code>esp32</code>; local chat uses UART0 automatically on targets without USB Serial/JTAG (no manual <code>CONFIG_ZCLAW_CHANNEL_UART</code> toggle needed).</p>
         </section>
 
         <section class="section">
@@ -220,6 +221,7 @@ idf.py menuconfig</pre>
         <section class="section">
           <h2>Other Board Notes</h2>
           <p>Most boards work with the generic target flow, but some need explicit board-safe pin/reset defaults.</p>
+          <p class="inline-note">If you move between chips (for example, C3/S3 to WROOM), accept the flash-script prompt to run <code>idf.py set-target &lt;chip&gt;</code> (or run it manually once).</p>
           <pre># ESP32-S3-BOX-3 preset
 ./scripts/build.sh --box-3
 ./scripts/flash.sh --box-3 /dev/cu.usbmodem1101
@@ -232,7 +234,7 @@ idf.py menuconfig</pre>
           <h2>If Something Breaks</h2>
           <pre># ESP-IDF repair
 cd ~/esp/esp-idf
-./install.sh esp32c3,esp32s3
+./install.sh esp32,esp32c3,esp32c6,esp32s3
 
 # Build/test routines
 ./scripts/build.sh

--- a/docs-site/reference/README_COMPLETE.md
+++ b/docs-site/reference/README_COMPLETE.md
@@ -62,6 +62,9 @@ Good choice: [Seeed XIAO ESP32-C3](https://www.seeedstudio.com/Seeed-XIAO-ESP32C
 
 Other options: ESP32-DevKitM, Adafruit QT Py, any generic ESP32 module.
 
+For ESP32-WROOM/ESP32 DevKit (`esp32` target), local chat automatically uses UART0 on targets
+without USB Serial/JTAG support. No manual `CONFIG_ZCLAW_CHANNEL_UART=y` toggle is required.
+
 ESP32-S3-BOX-3 preset:
 
 ```bash
@@ -286,7 +289,7 @@ User tools are compositions of built-in primitives (`gpio_write`, `delay`, `memo
 # Install ESP-IDF v5.4
 mkdir -p ~/esp && cd ~/esp
 git clone -b v5.4 --recursive https://github.com/espressif/esp-idf.git
-cd esp-idf && ./install.sh esp32c3,esp32s3
+cd esp-idf && ./install.sh esp32,esp32c3,esp32c6,esp32s3
 ```
 
 </details>
@@ -308,7 +311,7 @@ If `source ~/esp/esp-idf/export.sh` fails, repair ESP-IDF tools:
 
 ```bash
 cd ~/esp/esp-idf
-./install.sh esp32c3,esp32s3
+./install.sh esp32,esp32c3,esp32c6,esp32s3
 ```
 
 Or use the convenience scripts:
@@ -336,6 +339,7 @@ Or use the convenience scripts:
 
 `flash.sh` and `flash-secure.sh` auto-detect connected chip type and prompt to run
 `idf.py set-target <chip>` when project target does not match the board.
+If you switch between families (for example `esp32s3` to `esp32`), accept that prompt once.
 
 ### First Boot
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ VERSION_FILE="$SCRIPT_DIR/VERSION"
 ZCLAW_RELEASE_VERSION="dev"
 ESP_IDF_VERSION="v5.4"
 ESP_IDF_DIR="$HOME/esp/esp-idf"
-ESP_IDF_CHIPS="esp32c3,esp32s3"
+ESP_IDF_CHIPS="esp32,esp32c3,esp32c6,esp32s3"
 PREFS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/zclaw"
 PREFS_FILE="$PREFS_DIR/install.env"
 
@@ -1096,7 +1096,7 @@ echo ""
 
 echo -e "${BOLD}Pro tip:${NC} Add to your shell config:"
 echo -e "  ${YELLOW}alias idf='source ~/esp/esp-idf/export.sh'${NC}"
-echo -e "  ${DIM}If that fails: cd ~/esp/esp-idf && ./install.sh esp32c3,esp32s3${NC}"
+echo -e "  ${DIM}If that fails: cd ~/esp/esp-idf && ./install.sh esp32,esp32c3,esp32c6,esp32s3${NC}"
 if [ "$REMEMBER_PREFS" = true ]; then
     echo -e "  ${DIM}Installer defaults: $PREFS_FILE (${YELLOW}--no-remember${DIM} to disable)${NC}"
 fi

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -43,10 +43,12 @@ menu "zclaw Configuration"
 
     config ZCLAW_CHANNEL_UART
         bool "Use UART0 for local channel (QEMU-friendly)"
+        default y if !SOC_USB_SERIAL_JTAG_SUPPORTED
         default n
         help
             Uses UART0 instead of USB Serial/JTAG for local input/output.
             Enable this for interactive QEMU use.
+            Targets without USB Serial/JTAG default to UART automatically.
 
     config ZCLAW_EMULATOR_MODE
         bool "Offline emulator mode (skip WiFi/NTP/Telegram startup)"

--- a/main/channel.c
+++ b/main/channel.c
@@ -4,7 +4,15 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
-#if CONFIG_ZCLAW_CHANNEL_UART
+#include "soc/soc_caps.h"
+
+#if CONFIG_ZCLAW_CHANNEL_UART || !SOC_USB_SERIAL_JTAG_SUPPORTED
+#define ZCLAW_CHANNEL_USE_UART 1
+#else
+#define ZCLAW_CHANNEL_USE_UART 0
+#endif
+
+#if ZCLAW_CHANNEL_USE_UART
 #include "driver/uart.h"
 #else
 #include "driver/usb_serial_jtag.h"
@@ -31,7 +39,7 @@ static QueueHandle_t s_llm_bridge_queue = NULL;
 static char s_llm_bridge_payload[LLM_RESPONSE_BUF_SIZE];
 #endif
 
-#if CONFIG_ZCLAW_CHANNEL_UART
+#if ZCLAW_CHANNEL_USE_UART
 #define CHANNEL_UART_PORT UART_NUM_0
 #define CHANNEL_UART_BAUDRATE 115200
 
@@ -127,7 +135,7 @@ static void channel_write_normalized_text(const char *text, TickType_t timeout_t
 void channel_init(void)
 {
     channel_io_init();
-#if CONFIG_ZCLAW_CHANNEL_UART
+#if ZCLAW_CHANNEL_USE_UART
     ESP_LOGI(TAG, "UART0 channel initialized");
 #else
     ESP_LOGI(TAG, "USB serial initialized");

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -126,12 +126,12 @@ source_idf_env() {
     if [ "$found" -eq 1 ]; then
         echo "Error: ESP-IDF found but failed to activate."
         echo "Run:"
-        echo "  cd ~/esp/esp-idf && ./install.sh esp32c3,esp32s3"
+        echo "  cd ~/esp/esp-idf && ./install.sh esp32,esp32c3,esp32c6,esp32s3"
     else
         echo "Error: ESP-IDF not found. Install it first:"
         echo "  mkdir -p ~/esp && cd ~/esp"
         echo "  git clone -b v5.4 --recursive https://github.com/espressif/esp-idf.git"
-        echo "  cd esp-idf && ./install.sh esp32c3,esp32s3"
+        echo "  cd esp-idf && ./install.sh esp32,esp32c3,esp32c6,esp32s3"
     fi
     return 1
 }

--- a/scripts/erase.sh
+++ b/scripts/erase.sh
@@ -155,7 +155,7 @@ source_idf_env() {
     if [ "$found" -eq 1 ]; then
         echo "Error: ESP-IDF found but failed to activate."
         echo "Run:"
-        echo "  cd ~/esp/esp-idf && ./install.sh esp32c3,esp32s3"
+        echo "  cd ~/esp/esp-idf && ./install.sh esp32,esp32c3,esp32c6,esp32s3"
     else
         echo "Error: ESP-IDF not found"
     fi

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -112,7 +112,7 @@ source_idf_env() {
     if [ "$found" -eq 1 ]; then
         echo "Error: ESP-IDF found but failed to activate."
         echo "Run:"
-        echo "  cd ~/esp/esp-idf && ./install.sh esp32c3,esp32s3"
+        echo "  cd ~/esp/esp-idf && ./install.sh esp32,esp32c3,esp32c6,esp32s3"
     else
         echo "Error: ESP-IDF not found"
     fi

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -339,7 +339,7 @@ source_idf_env() {
     if [ "$found" -eq 1 ]; then
         echo "Error: ESP-IDF found but failed to activate."
         echo "Run:"
-        echo "  cd ~/esp/esp-idf && ./install.sh esp32c3,esp32s3"
+        echo "  cd ~/esp/esp-idf && ./install.sh esp32,esp32c3,esp32c6,esp32s3"
     else
         echo "Error: ESP-IDF not found"
     fi


### PR DESCRIPTION
## Summary
- default `CONFIG_ZCLAW_CHANNEL_UART` when USB Serial/JTAG is not supported (e.g. classic ESP32/WROOM targets)
- add a channel fallback in `main/channel.c` so non-USB targets route to UART at compile time
- expand install/tooling chip list and docs/help text to include `esp32c6`
- harden `scripts/flash.sh` and `scripts/flash-secure.sh` by resolving `esptool` via IDF Python env fallback when `esptool.py` is not on PATH
- add host tests covering C6 chip list, UART auto-default logic, and esptool fallback chip detection

## Scope Guard
- no voice/wake-word/STT/TTS changes in this branch

## Validation
- `python3 -m unittest -q test_install_provision_scripts.py` (pass)
- `bash -n scripts/flash.sh scripts/flash-secure.sh` (pass)
- hardware validation on ESP32-S3 (`/dev/cu.usbmodem1101`): install/build/flash path completed successfully after target switch detection
