### PR TITLE
feat: add scoped diagnostics tool and local /diag command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Non-interactive install:
 - Chat via Telegram or hosted web relay
 - Timezone-aware schedules (`daily`, `periodic`, and one-shot `once`)
 - Built-in + user-defined tools
+- Runtime diagnostics via `get_diagnostics` (quick/runtime/memory/rates/time/all scopes)
 - GPIO read/write control with guardrails (including bulk `gpio_read_all`)
 - Persistent memory across reboots
 - Persona options: `neutral`, `friendly`, `technical`, `witty`

--- a/docs-site/reference/README_COMPLETE.md
+++ b/docs-site/reference/README_COMPLETE.md
@@ -213,6 +213,7 @@ This relay approach does not add web UI code to ESP32 firmware binary.
 | `get_timezone` | Show current device timezone |
 | `get_version` | Get firmware version |
 | `get_health` | Get device health (heap, rate limits, time sync, version) |
+| `get_diagnostics` | Get scoped runtime diagnostics (`quick`, `runtime`, `memory`, `rates`, `time`, `all`) |
 | `create_tool` | Create a custom user-defined tool |
 | `list_user_tools` | List all user-created tools |
 | `delete_user_tool` | Delete a user-created tool |
@@ -224,6 +225,37 @@ Example tool call input:
 
 ```json
 {"sda_pin":8,"scl_pin":9,"frequency_hz":100000}
+```
+
+### Runtime Diagnostics (`get_diagnostics`)
+
+`get_diagnostics` is a deeper companion to `get_health`. It supports scoped checks plus an optional `verbose` mode.
+For Telegram control-plane checks without an LLM round trip, use `/diag [scope] [verbose]`.
+
+- `scope: quick` (default) — one-line snapshot for uptime, heap, rates, time sync, timezone, boot count, and version
+- `scope: runtime` — uptime, boot count, firmware version
+- `scope: memory` — free/min/largest heap plus fragmentation hint
+- `scope: rates` — request counters (`/hr`, `/day`)
+- `scope: time` — sync status and timezone
+- `scope: all` — multi-line summary across all categories
+- `verbose: true` — includes expanded details (for example raw uptime microseconds)
+
+Example tool call inputs:
+
+```json
+{}
+```
+
+```json
+{"scope":"memory","verbose":true}
+```
+
+Example natural-language prompts:
+
+```text
+Run diagnostics.
+Show full diagnostics.
+Check memory diagnostics in verbose mode.
 ```
 
 ### Timezone And Daily Schedules

--- a/docs-site/tools.html
+++ b/docs-site/tools.html
@@ -64,10 +64,26 @@
               <tr><td>Memory</td><td><code>memory_set</code>, <code>memory_get</code>, <code>memory_list</code>, <code>memory_delete</code></td><td>Persistent user state (<code>u_*</code> keys).</td></tr>
               <tr><td>Schedules</td><td><code>cron_set</code>, <code>cron_list</code>, <code>cron_delete</code></td><td>Periodic, daily, and one-shot jobs.</td></tr>
               <tr><td>Clock</td><td><code>get_time</code>, <code>set_timezone</code>, <code>get_timezone</code></td><td>Timezone-aware schedule behavior.</td></tr>
-              <tr><td>System</td><td><code>get_version</code>, <code>get_health</code></td><td>Firmware + runtime diagnostics.</td></tr>
+              <tr><td>System</td><td><code>get_version</code>, <code>get_health</code>, <code>get_diagnostics</code></td><td>Firmware version plus quick/scoped runtime diagnostics.</td></tr>
               <tr><td>User tools</td><td><code>create_tool</code>, <code>list_user_tools</code>, <code>delete_user_tool</code></td><td>Natural-language macro layer.</td></tr>
             </tbody>
           </table>
+        </section>
+
+        <section class="section">
+          <h2>Runtime Diagnostics</h2>
+          <p><code>get_diagnostics</code> extends <code>get_health</code> with scoped checks and optional verbose output.</p>
+          <ul>
+            <li><code>scope: quick</code> (default) for one-line status.</li>
+            <li><code>scope: runtime</code> for uptime + boot/version context.</li>
+            <li><code>scope: memory</code> for free/min/largest heap and fragmentation hint.</li>
+            <li><code>scope: rates</code> for request counters.</li>
+            <li><code>scope: time</code> for sync + timezone.</li>
+            <li><code>scope: all</code> for a multi-line summary across categories.</li>
+            <li><code>verbose: true</code> includes expanded details.</li>
+          </ul>
+          <pre>{"scope":"memory","verbose":true}</pre>
+          <p class="inline-note">Natural-language prompts like “run diagnostics” or “show full diagnostics” should trigger this tool.</p>
         </section>
 
         <section class="section">
@@ -80,6 +96,7 @@
               <tr><td><code>/start</code></td><td>Shows local command help without calling the LLM.</td></tr>
               <tr><td><code>/help</code></td><td>Alias of <code>/start</code>; returns local command help without calling the LLM.</td></tr>
               <tr><td><code>/settings</code></td><td>Shows local bot status (including paused/active intake state).</td></tr>
+              <tr><td><code>/diag [scope] [verbose]</code></td><td>Runs local diagnostics without an LLM call (available even when intake is paused).</td></tr>
               <tr><td><code>/stop</code></td><td>Pauses inbound message processing (used to stop spam loops).</td></tr>
               <tr><td><code>/resume</code></td><td>Re-enables inbound message processing after <code>/stop</code>.</td></tr>
             </tbody>

--- a/main/tools.c
+++ b/main/tools.c
@@ -137,6 +137,12 @@ static const tool_def_t s_tools[] = {
         .input_schema_json = "{\"type\":\"object\",\"properties\":{}}",
         .execute = tools_get_health_handler
     },
+    {
+        .name = "get_diagnostics",
+        .description = "Get detailed runtime diagnostics. Optional scope: quick, runtime, memory, rates, time, all. Optional verbose=true for expanded output.",
+        .input_schema_json = "{\"type\":\"object\",\"properties\":{\"scope\":{\"type\":\"string\",\"enum\":[\"quick\",\"runtime\",\"memory\",\"rates\",\"time\",\"all\"],\"description\":\"Optional diagnostics scope (default quick)\"},\"verbose\":{\"type\":\"boolean\",\"description\":\"Include extra details (default false)\"}}}",
+        .execute = tools_get_diagnostics_handler
+    },
     // User Tool Management
     {
         .name = "create_tool",

--- a/main/tools_handlers.h
+++ b/main/tools_handlers.h
@@ -37,6 +37,7 @@ bool tools_get_timezone_handler(const cJSON *input, char *result, size_t result_
 // System / User tools
 bool tools_get_version_handler(const cJSON *input, char *result, size_t result_len);
 bool tools_get_health_handler(const cJSON *input, char *result, size_t result_len);
+bool tools_get_diagnostics_handler(const cJSON *input, char *result, size_t result_len);
 bool tools_create_tool_handler(const cJSON *input, char *result, size_t result_len);
 bool tools_list_user_tools_handler(const cJSON *input, char *result, size_t result_len);
 bool tools_delete_user_tool_handler(const cJSON *input, char *result, size_t result_len);

--- a/main/tools_system.c
+++ b/main/tools_system.c
@@ -1,11 +1,189 @@
 #include "tools_handlers.h"
 #include "config.h"
+#include "memory.h"
+#include "nvs_keys.h"
 #include "ota.h"
 #include "ratelimit.h"
 #include "cron.h"
 #include "user_tools.h"
+#include "esp_heap_caps.h"
 #include "esp_system.h"
+#include "esp_timer.h"
 #include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef enum {
+    DIAG_SCOPE_QUICK = 0,
+    DIAG_SCOPE_RUNTIME,
+    DIAG_SCOPE_MEMORY,
+    DIAG_SCOPE_RATES,
+    DIAG_SCOPE_TIME,
+    DIAG_SCOPE_ALL,
+} diag_scope_t;
+
+static void format_uptime(int64_t uptime_us, char *buf, size_t buf_len)
+{
+    uint64_t total_s;
+    uint64_t days;
+    uint64_t hours;
+    uint64_t minutes;
+    uint64_t seconds;
+
+    if (!buf || buf_len == 0) {
+        return;
+    }
+
+    if (uptime_us <= 0) {
+        snprintf(buf, buf_len, "unknown");
+        return;
+    }
+
+    total_s = (uint64_t)uptime_us / 1000000ULL;
+    days = total_s / 86400ULL;
+    total_s %= 86400ULL;
+    hours = total_s / 3600ULL;
+    total_s %= 3600ULL;
+    minutes = total_s / 60ULL;
+    seconds = total_s % 60ULL;
+
+    if (days > 0) {
+        snprintf(buf, buf_len,
+                 "%llud %02lluh %02llum %02llus",
+                 (unsigned long long)days,
+                 (unsigned long long)hours,
+                 (unsigned long long)minutes,
+                 (unsigned long long)seconds);
+        return;
+    }
+    if (hours > 0) {
+        snprintf(buf, buf_len,
+                 "%lluh %02llum %02llus",
+                 (unsigned long long)hours,
+                 (unsigned long long)minutes,
+                 (unsigned long long)seconds);
+        return;
+    }
+    if (minutes > 0) {
+        snprintf(buf, buf_len,
+                 "%llum %02llus",
+                 (unsigned long long)minutes,
+                 (unsigned long long)seconds);
+        return;
+    }
+
+    snprintf(buf, buf_len, "%llus", (unsigned long long)seconds);
+}
+
+static unsigned diag_fragmentation_percent(uint32_t free_heap, uint32_t largest_block)
+{
+    if (free_heap == 0 || largest_block >= free_heap) {
+        return 0;
+    }
+    return 100U - (unsigned)((largest_block * 100U) / free_heap);
+}
+
+static uint32_t diag_get_free_heap_size(void)
+{
+#ifdef TEST_BUILD
+    return 0;
+#else
+    return (uint32_t)esp_get_free_heap_size();
+#endif
+}
+
+static uint32_t diag_get_minimum_free_heap_size(void)
+{
+#ifdef TEST_BUILD
+    return 0;
+#else
+    return (uint32_t)esp_get_minimum_free_heap_size();
+#endif
+}
+
+static uint32_t diag_get_largest_heap_block(void)
+{
+#ifdef TEST_BUILD
+    return 0;
+#else
+    return (uint32_t)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+#endif
+}
+
+static bool diagnostics_scope_from_text(const char *scope_text, diag_scope_t *scope)
+{
+    if (!scope_text || !scope) {
+        return false;
+    }
+
+    if (strcmp(scope_text, "quick") == 0) {
+        *scope = DIAG_SCOPE_QUICK;
+        return true;
+    }
+    if (strcmp(scope_text, "runtime") == 0) {
+        *scope = DIAG_SCOPE_RUNTIME;
+        return true;
+    }
+    if (strcmp(scope_text, "memory") == 0) {
+        *scope = DIAG_SCOPE_MEMORY;
+        return true;
+    }
+    if (strcmp(scope_text, "rates") == 0) {
+        *scope = DIAG_SCOPE_RATES;
+        return true;
+    }
+    if (strcmp(scope_text, "time") == 0) {
+        *scope = DIAG_SCOPE_TIME;
+        return true;
+    }
+    if (strcmp(scope_text, "all") == 0) {
+        *scope = DIAG_SCOPE_ALL;
+        return true;
+    }
+
+    return false;
+}
+
+static bool parse_diagnostics_args(const cJSON *input,
+                                   diag_scope_t *scope_out,
+                                   bool *verbose_out,
+                                   char *result,
+                                   size_t result_len)
+{
+    const cJSON *scope_json;
+    const cJSON *verbose_json;
+
+    *scope_out = DIAG_SCOPE_QUICK;
+    *verbose_out = false;
+
+    if (!input) {
+        return true;
+    }
+
+    scope_json = cJSON_GetObjectItemCaseSensitive((cJSON *)input, "scope");
+    if (scope_json) {
+        if (!cJSON_IsString(scope_json) || !scope_json->valuestring || scope_json->valuestring[0] == '\0') {
+            snprintf(result, result_len, "Error: scope must be one of quick|runtime|memory|rates|time|all");
+            return false;
+        }
+        if (!diagnostics_scope_from_text(scope_json->valuestring, scope_out)) {
+            snprintf(result, result_len, "Error: unknown scope '%s' (use quick|runtime|memory|rates|time|all)",
+                     scope_json->valuestring);
+            return false;
+        }
+    }
+
+    verbose_json = cJSON_GetObjectItemCaseSensitive((cJSON *)input, "verbose");
+    if (verbose_json) {
+        if (!cJSON_IsBool(verbose_json)) {
+            snprintf(result, result_len, "Error: verbose must be boolean");
+            return false;
+        }
+        *verbose_out = cJSON_IsTrue(verbose_json);
+    }
+
+    return true;
+}
 
 bool tools_get_version_handler(const cJSON *input, char *result, size_t result_len)
 {
@@ -19,8 +197,8 @@ bool tools_get_health_handler(const cJSON *input, char *result, size_t result_le
     (void)input;
 
     // Get heap info
-    uint32_t free_heap = esp_get_free_heap_size();
-    uint32_t min_heap = esp_get_minimum_free_heap_size();
+    uint32_t free_heap = diag_get_free_heap_size();
+    uint32_t min_heap = diag_get_minimum_free_heap_size();
 
     // Get rate limit info
     int requests_hour = ratelimit_get_requests_this_hour();
@@ -50,6 +228,164 @@ bool tools_get_health_handler(const cJSON *input, char *result, size_t result_le
              ota_get_version());
 
     return true;
+}
+
+bool tools_get_diagnostics_handler(const cJSON *input, char *result, size_t result_len)
+{
+    uint32_t free_heap = diag_get_free_heap_size();
+    uint32_t min_heap = diag_get_minimum_free_heap_size();
+    uint32_t largest_heap = diag_get_largest_heap_block();
+    unsigned fragmentation_pct = diag_fragmentation_percent(free_heap, largest_heap);
+    int requests_hour = ratelimit_get_requests_this_hour();
+    int requests_day = ratelimit_get_requests_today();
+    bool time_synced = cron_is_time_synced();
+    char timezone_posix[TIMEZONE_MAX_LEN];
+    char timezone_abbrev[16];
+    char boot_count[16] = "unknown";
+    char uptime_text[48];
+    int64_t uptime_us = esp_timer_get_time();
+    diag_scope_t scope = DIAG_SCOPE_QUICK;
+    bool verbose = false;
+
+    if (!parse_diagnostics_args(input, &scope, &verbose, result, result_len)) {
+        return false;
+    }
+
+    cron_get_timezone(timezone_posix, sizeof(timezone_posix));
+    cron_get_timezone_abbrev(timezone_abbrev, sizeof(timezone_abbrev));
+    (void)memory_get(NVS_KEY_BOOT_COUNT, boot_count, sizeof(boot_count));
+    format_uptime(uptime_us, uptime_text, sizeof(uptime_text));
+
+    switch (scope) {
+        case DIAG_SCOPE_RUNTIME:
+            if (verbose) {
+                snprintf(result, result_len,
+                         "Runtime diagnostics:\n"
+                         "- Uptime: %s (%llu us)\n"
+                         "- Boot count: %s\n"
+                         "- Version: %s",
+                         uptime_text,
+                         (unsigned long long)((uptime_us > 0) ? uptime_us : 0),
+                         boot_count,
+                         ota_get_version());
+            } else {
+                snprintf(result, result_len,
+                         "Runtime: uptime=%s | boot_count=%s | version=%s",
+                         uptime_text,
+                         boot_count,
+                         ota_get_version());
+            }
+            return true;
+        case DIAG_SCOPE_MEMORY:
+            if (verbose) {
+                snprintf(result, result_len,
+                         "Memory diagnostics:\n"
+                         "- Heap free: %lu bytes\n"
+                         "- Heap min: %lu bytes\n"
+                         "- Heap largest block: %lu bytes\n"
+                         "- Fragmentation hint: %u%%",
+                         (unsigned long)free_heap,
+                         (unsigned long)min_heap,
+                         (unsigned long)largest_heap,
+                         fragmentation_pct);
+            } else {
+                snprintf(result, result_len,
+                         "Memory: free=%lu | min=%lu | largest=%lu | frag~%u%%",
+                         (unsigned long)free_heap,
+                         (unsigned long)min_heap,
+                         (unsigned long)largest_heap,
+                         fragmentation_pct);
+            }
+            return true;
+        case DIAG_SCOPE_RATES:
+            snprintf(result, result_len,
+                     "Rates: requests=%d/hr, %d/day",
+                     requests_hour,
+                     requests_day);
+            return true;
+        case DIAG_SCOPE_TIME:
+            if (verbose) {
+                snprintf(result, result_len,
+                         "Time diagnostics:\n"
+                         "- Sync: %s\n"
+                         "- Timezone (POSIX): %s\n"
+                         "- Timezone (abbr): %s",
+                         time_synced ? "synced" : "not synced",
+                         timezone_posix,
+                         timezone_abbrev);
+            } else {
+                snprintf(result, result_len,
+                         "Time: %s | tz=%s (%s)",
+                         time_synced ? "synced" : "not synced",
+                         timezone_posix,
+                         timezone_abbrev);
+            }
+            return true;
+        case DIAG_SCOPE_ALL:
+            if (verbose) {
+                snprintf(result, result_len,
+                         "Diagnostics:\n"
+                         "- Uptime: %s (%llu us)\n"
+                         "- Heap: free=%lu min=%lu largest=%lu frag~%u%%\n"
+                         "- Requests: %d/hr, %d/day\n"
+                         "- Time sync: %s\n"
+                         "- Timezone: %s (%s)\n"
+                         "- Boot count: %s\n"
+                         "- Version: %s",
+                         uptime_text,
+                         (unsigned long long)((uptime_us > 0) ? uptime_us : 0),
+                         (unsigned long)free_heap,
+                         (unsigned long)min_heap,
+                         (unsigned long)largest_heap,
+                         fragmentation_pct,
+                         requests_hour,
+                         requests_day,
+                         time_synced ? "synced" : "not synced",
+                         timezone_posix,
+                         timezone_abbrev,
+                         boot_count,
+                         ota_get_version());
+            } else {
+                snprintf(result, result_len,
+                         "Diagnostics:\n"
+                         "- Uptime: %s\n"
+                         "- Heap: free=%lu min=%lu largest=%lu frag~%u%%\n"
+                         "- Requests: %d/hr, %d/day\n"
+                         "- Time sync: %s\n"
+                         "- Timezone: %s (%s)\n"
+                         "- Boot count: %s\n"
+                         "- Version: %s",
+                         uptime_text,
+                         (unsigned long)free_heap,
+                         (unsigned long)min_heap,
+                         (unsigned long)largest_heap,
+                         fragmentation_pct,
+                         requests_hour,
+                         requests_day,
+                         time_synced ? "synced" : "not synced",
+                         timezone_posix,
+                         timezone_abbrev,
+                         boot_count,
+                         ota_get_version());
+            }
+            return true;
+        case DIAG_SCOPE_QUICK:
+        default:
+            snprintf(result, result_len,
+                     "Diag: uptime=%s | heap=%lu/%lu/%lu | req=%d/hr,%d/day | time=%s | tz=%s (%s) | boot=%s | v=%s",
+                     uptime_text,
+                     (unsigned long)free_heap,
+                     (unsigned long)min_heap,
+                     (unsigned long)largest_heap,
+                     requests_hour,
+                     requests_day,
+                     time_synced ? "synced" : "not synced",
+                     timezone_posix,
+                     timezone_abbrev,
+                     boot_count,
+                     ota_get_version());
+            return true;
+    }
 }
 
 bool tools_create_tool_handler(const cJSON *input, char *result, size_t result_len)

--- a/test/api/provider_harness.py
+++ b/test/api/provider_harness.py
@@ -146,6 +146,24 @@ TOOLS = [
         "input_schema": {"type": "object", "properties": {}},
     },
     {
+        "name": "get_diagnostics",
+        "description": "Get detailed runtime diagnostics. Optional scope: quick, runtime, memory, rates, time, all. Optional verbose=true for expanded output.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "scope": {
+                    "type": "string",
+                    "enum": ["quick", "runtime", "memory", "rates", "time", "all"],
+                    "description": "Optional diagnostics scope (default quick)",
+                },
+                "verbose": {
+                    "type": "boolean",
+                    "description": "Include extra details (default false)",
+                },
+            },
+        },
+    },
+    {
         "name": "create_tool",
         "description": "Create a custom tool. Provide a short name (no spaces), brief description, and the action to perform when called.",
         "input_schema": {
@@ -191,6 +209,7 @@ MOCK_RESULTS = {
     "get_time": lambda inp: "2026-02-21 14:30:00 UTC",
     "get_version": lambda inp: "zclaw v2.0.4",
     "get_health": lambda inp: "Health: OK | Heap: 180000 free | Requests: 5/hr, 20/day | Time: synced",
+    "get_diagnostics": lambda inp: "Diagnostics: uptime=2h 14m | heap=180000/120000/90000 | req=5/hr,20/day",
     "create_tool": lambda inp: f"Created tool '{inp.get('name')}': {inp.get('description')}",
     "list_user_tools": lambda inp: "No user tools defined",
     "delete_user_tool": lambda inp: f"Deleted tool '{inp.get('name')}'",


### PR DESCRIPTION
## Summary
- add new built-in `get_diagnostics` tool with scoped output (`quick`, `runtime`, `memory`, `rates`, `time`, `all`) and optional `verbose`
- keep existing `get_health` behavior unchanged for compatibility
- add local Telegram control command `/diag [scope] [verbose]` that bypasses the LLM and remains available while paused
- update docs across README, full README, and docs-site tool surface
- sync offline provider harness tool metadata with firmware tool surface

## Testing
- `./scripts/test.sh host`
