### PR TITLE
fix: support non-apt Linux package managers in installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
-- No unreleased changes yet.
+### Fixed
+- Linux installer dependency steps no longer hard-code `apt`; `install.sh` now detects and uses `apt-get`, `pacman`, `dnf`, or `zypper`.
+
+### Changed
+- Non-interactive installer prompts now default to `no` unless `-y`, explicit flags, or saved defaults are provided.
+- Linux optional dependency installs (`QEMU`, `cJSON`) now use distro-specific package names per detected package manager.
+
+### Docs
+- Updated README, full reference README, and Getting Started docs with Linux package-manager detection and non-interactive prompt behavior.
+
+### Tests
+- Added host install-script coverage for Linux package-manager detection (`pacman`) and unsupported-manager fallback behavior.
 
 ## [2.8.2] - 2026-03-01
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Non-interactive install:
 <summary>Setup notes</summary>
 
 - `bootstrap.sh` clones/updates the repo and then runs `./install.sh`. You can inspect/verify the bootstrap flow first (including `ZCLAW_BOOTSTRAP_SHA256` integrity checks); see the [Getting Started docs](https://zclaw.dev/getting-started.html).
+- Linux dependency installs auto-detect `apt-get`, `pacman`, `dnf`, or `zypper` during `install.sh` runs.
+- In non-interactive mode, unanswered install prompts default to `no` unless you pass `-y` (or saved preferences/explicit flags apply).
 - For encrypted credentials in flash, use secure mode (`--flash-mode secure` in install flow, or `./scripts/flash-secure.sh` directly).
 - After flashing, provision WiFi + LLM credentials with `./scripts/provision.sh`.
 - You can re-run either `./scripts/provision.sh` or `./scripts/provision-dev.sh` at any time (no reflash required) to update runtime credentials: WiFi SSID/password, LLM backend/model/API key (or Ollama API URL), and Telegram token/chat ID allowlist.

--- a/docs-site/changelog.html
+++ b/docs-site/changelog.html
@@ -57,7 +57,9 @@
           <h2>Current Stream</h2>
           <p><strong>Unreleased</strong></p>
           <ul>
-            <li>No unreleased changes yet.</li>
+            <li>Linux installer package support expanded: <code>install.sh</code> now auto-detects <code>apt-get</code>, <code>pacman</code>, <code>dnf</code>, and <code>zypper</code> instead of hard-coding <code>apt</code>.</li>
+            <li>Non-interactive installer prompts now default to <code>no</code> unless <code>-y</code>, explicit flags, or saved preferences are present.</li>
+            <li>Added host tests for Linux package-manager detection and unsupported-manager fallback in the install flow.</li>
           </ul>
           <p class="inline-note">Source of truth: <a href="https://github.com/tnm/zclaw/blob/main/CHANGELOG.md">CHANGELOG.md in repo</a>.</p>
         </section>

--- a/docs-site/getting-started.html
+++ b/docs-site/getting-started.html
@@ -74,8 +74,9 @@ bash &lt;(curl -fsSL https://raw.githubusercontent.com/tnm/zclaw/main/scripts/bo
           <ul>
             <li>Installer remembers answers in <code>~/.config/zclaw/install.env</code> (disable with <code>--no-remember</code>).</li>
             <li>Interactive flashing defaults to standard mode; encrypted flashing is opt-in with <code>--flash-mode secure</code>.</li>
+            <li>On Linux, dependency installs auto-detect <code>apt-get</code>, <code>pacman</code>, <code>dnf</code>, or <code>zypper</code>; unsupported distros fall back to manual package install guidance.</li>
           </ul>
-          <p class="inline-note">Want non-interactive install? Use <code>-y</code> and explicit no/yes flags: <code>./install.sh -y --build --flash --provision --no-qemu --no-cjson</code>.</p>
+          <p class="inline-note">Want non-interactive install? Use <code>-y</code> and explicit no/yes flags: <code>./install.sh -y --build --flash --provision --no-qemu --no-cjson</code>. Without <code>-y</code>, unanswered non-interactive prompts default to <code>no</code>.</p>
         </section>
 
         <section class="section">

--- a/docs-site/reference/README_COMPLETE.md
+++ b/docs-site/reference/README_COMPLETE.md
@@ -100,6 +100,9 @@ It also points you to flash helpers that auto-detect serial port/chip and can sw
 It remembers your choices in `~/.config/zclaw/install.env` (disable with `--no-remember`).
 Saved QEMU/cJSON answers are auto-applied on future runs (override with `--qemu/--no-qemu` and `--cjson/--no-cjson`).
 Interactive `install.sh` flashing defaults to standard mode; flash encryption is only enabled with `--flash-mode secure`.
+On Linux, `install.sh` auto-detects `apt-get`, `pacman`, `dnf`, or `zypper` for dependency installs.
+If no supported manager is detected, it skips auto-install and prints manual package guidance.
+In non-interactive runs, unanswered prompts default to `no` unless you pass `-y` (or set explicit install flags/saved defaults).
 
 <details>
 <summary>You can also preseed install flags (click to expand)</summary>


### PR DESCRIPTION
  ## Summary
  - detect Linux package managers in `install.sh` (`apt-get`, `pacman`, `dnf`, `zypper`) and route
  dependency installs through the detected manager
  - replace apt-only optional dependency installs (`QEMU`, `cJSON`) with distro-specific packages and
  graceful unsupported-manager fallback messaging
  - make non-interactive prompt defaults safer by defaulting unanswered prompts to `no` unless `-y`,
  saved defaults, or explicit flags are provided
  - update README/docs-site docs and changelog entries to reflect new installer behavior
  - add host tests covering pacman routing and unknown package-manager fallback paths

  ## Testing
  - `bash -n install.sh`
  - `python3 -m pytest -q test/host/test_install_provision_scripts.py`

  ## Notes
  - macOS/Homebrew install path remains unchanged
  - apt-based Linux path remains supported via package-manager detection