### PR TITLE
feat(api): auto-insert system role in call_api for IoT messages

### DIFF
--- a/test/api/provider_harness.py
+++ b/test/api/provider_harness.py
@@ -324,6 +324,13 @@ def call_api(
             headers["X-Title"] = os.environ.get("OPENROUTER_X_TITLE", "zclaw api tests")
 
         token_field, token_value = _openai_like_max_tokens_field(model)
+
+        if not messages or messages[0].get("role") != "system":
+            messages = [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                *messages,
+            ]
+
         payload = {
             "model": model,
             token_field: token_value,


### PR DESCRIPTION
- Automatically prepends a system message if none exists

Before

```
zclaw API Test Harness
Provider: openrouter
Model: minimax/minimax-m2.5
Type messages to send to the model. Type 'quit' to exit.
Type 'tools' to see available tools.
Type 'user_tools' to see created user tools.

You: Hi, who are you?

============================================================
PROVIDER: openrouter
MODEL: minimax/minimax-m2.5
USER: Hi, who are you?
============================================================

--- Round 1 (stop_reason: stop) ---
TEXT: Hello! I'm an AI assistant built by MiniMax, and I'm here to help you with a variety of tasks. I have access to several tools that allow me to interact with and manage a hardware device.
```

After

```
Type messages to send to the model. Type 'quit' to exit.
Type 'tools' to see available tools.
Type 'user_tools' to see created user tools.

You: Hi, who are you?

============================================================
PROVIDER: openrouter
MODEL: minimax/minimax-m2.5
USER: Hi, who are you?
============================================================

--- Round 1 (stop_reason: stop) ---
TEXT: I'm **zclaw**, an AI agent running on an ESP32 microcontroller. I have 400KB RAM and run bare metal with FreeRTOS.
```