### PR TITLE
fix(i2c): enforce shared gpio pin safety policy

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -7,6 +7,7 @@ idf_component_register(
         "llm_auth.c"
         "tools.c"
         "tools_common.c"
+        "gpio_policy.c"
         "tools_gpio.c"
         "tools_i2c.c"
         "tools_memory.c"

--- a/main/gpio_policy.c
+++ b/main/gpio_policy.c
@@ -1,0 +1,122 @@
+#include "gpio_policy.h"
+
+#include "config.h"
+#include "driver/gpio.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <limits.h>
+
+#ifndef GPIO_IS_VALID_GPIO
+#define GPIO_IS_VALID_GPIO(pin) ((pin) >= 0)
+#endif
+
+static bool pin_in_allowlist(int pin, const char *csv)
+{
+    const char *cursor;
+
+    if (!csv || csv[0] == '\0') {
+        return false;
+    }
+
+    cursor = csv;
+    while (*cursor != '\0') {
+        char *endptr = NULL;
+        long value;
+
+        while (*cursor == ' ' || *cursor == '\t' || *cursor == ',') {
+            cursor++;
+        }
+        if (*cursor == '\0') {
+            break;
+        }
+
+        value = strtol(cursor, &endptr, 10);
+        if (endptr == cursor) {
+            while (*cursor != '\0' && *cursor != ',') {
+                cursor++;
+            }
+            continue;
+        }
+
+        if ((int)value == pin) {
+            return true;
+        }
+        cursor = endptr;
+    }
+
+    return false;
+}
+
+static bool pin_is_allowed_impl(int pin,
+                                const char *allowlist_csv,
+                                int min_pin,
+                                int max_pin,
+                                bool block_esp32_flash_pins,
+                                bool require_valid_gpio)
+{
+    bool in_policy;
+
+    if (pin < 0) {
+        return false;
+    }
+
+    if (block_esp32_flash_pins && pin >= 6 && pin <= 11) {
+        return false;
+    }
+
+    if (allowlist_csv && allowlist_csv[0] != '\0') {
+        in_policy = pin_in_allowlist(pin, allowlist_csv);
+    } else {
+        in_policy = pin >= min_pin && pin <= max_pin;
+    }
+
+    if (!in_policy) {
+        return false;
+    }
+
+    if (require_valid_gpio) {
+        return GPIO_IS_VALID_GPIO((gpio_num_t)pin);
+    }
+
+    return true;
+}
+
+bool gpio_policy_pin_is_allowed(int pin)
+{
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    return pin_is_allowed_impl(pin, GPIO_ALLOWED_PINS_CSV, GPIO_MIN_PIN, GPIO_MAX_PIN, true, true);
+#else
+    return pin_is_allowed_impl(pin, GPIO_ALLOWED_PINS_CSV, GPIO_MIN_PIN, GPIO_MAX_PIN, false, true);
+#endif
+}
+
+bool gpio_policy_pin_forbidden_hint(int pin, char *result, size_t result_len)
+{
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    if (pin >= 6 && pin <= 11) {
+        snprintf(result, result_len,
+                 "Error: pin %d is reserved for ESP32 flash/PSRAM (GPIO6-11); choose a different pin",
+                 pin);
+        return true;
+    }
+#else
+    (void)pin;
+    (void)result;
+    (void)result_len;
+#endif
+
+    return false;
+}
+
+#ifdef TEST_BUILD
+bool gpio_policy_test_pin_is_allowed(int pin,
+                                     const char *csv,
+                                     int min_pin,
+                                     int max_pin,
+                                     bool block_esp32_flash_pins,
+                                     bool require_valid_gpio)
+{
+    return pin_is_allowed_impl(pin, csv, min_pin, max_pin, block_esp32_flash_pins, require_valid_gpio);
+}
+#endif

--- a/main/gpio_policy.h
+++ b/main/gpio_policy.h
@@ -1,0 +1,19 @@
+#ifndef GPIO_POLICY_H
+#define GPIO_POLICY_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+bool gpio_policy_pin_is_allowed(int pin);
+bool gpio_policy_pin_forbidden_hint(int pin, char *result, size_t result_len);
+
+#ifdef TEST_BUILD
+bool gpio_policy_test_pin_is_allowed(int pin,
+                                     const char *csv,
+                                     int min_pin,
+                                     int max_pin,
+                                     bool block_esp32_flash_pins,
+                                     bool require_valid_gpio);
+#endif
+
+#endif  // GPIO_POLICY_H

--- a/main/tools_gpio.c
+++ b/main/tools_gpio.c
@@ -1,5 +1,6 @@
 #include "tools_handlers.h"
 #include "config.h"
+#include "gpio_policy.h"
 #include "driver/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
@@ -13,92 +14,6 @@
 #define DELAY_MAX_MS 60000
 
 static const char *TAG = "tools";
-
-#ifndef GPIO_IS_VALID_GPIO
-#define GPIO_IS_VALID_GPIO(pin) ((pin) >= 0)
-#endif
-
-static bool gpio_pin_in_allowlist(int pin, const char *csv)
-{
-    const char *cursor;
-
-    if (!csv || csv[0] == '\0') {
-        return false;
-    }
-
-    cursor = csv;
-    while (*cursor != '\0') {
-        char *endptr = NULL;
-        long value;
-
-        while (*cursor == ' ' || *cursor == '\t' || *cursor == ',') {
-            cursor++;
-        }
-        if (*cursor == '\0') {
-            break;
-        }
-
-        value = strtol(cursor, &endptr, 10);
-        if (endptr == cursor) {
-            while (*cursor != '\0' && *cursor != ',') {
-                cursor++;
-            }
-            continue;
-        }
-
-        if ((int)value == pin) {
-            return true;
-        }
-        cursor = endptr;
-    }
-
-    return false;
-}
-
-static bool gpio_pin_is_allowed(int pin)
-{
-    bool in_policy;
-
-    if (pin < 0) {
-        return false;
-    }
-
-#if defined(CONFIG_IDF_TARGET_ESP32)
-    // ESP32-WROOM flash is wired to GPIO6..GPIO11; touching these pins can crash/hang.
-    if (pin >= 6 && pin <= 11) {
-        return false;
-    }
-#endif
-
-    if (GPIO_ALLOWED_PINS_CSV[0] != '\0') {
-        in_policy = gpio_pin_in_allowlist(pin, GPIO_ALLOWED_PINS_CSV);
-    } else {
-        in_policy = pin >= GPIO_MIN_PIN && pin <= GPIO_MAX_PIN;
-    }
-
-    if (!in_policy) {
-        return false;
-    }
-
-    return GPIO_IS_VALID_GPIO((gpio_num_t)pin);
-}
-
-static bool gpio_pin_forbidden_hint(int pin, char *result, size_t result_len)
-{
-#if defined(CONFIG_IDF_TARGET_ESP32)
-    if (pin >= 6 && pin <= 11) {
-        snprintf(result, result_len,
-                 "Error: pin %d is reserved for ESP32 flash/PSRAM (GPIO6-11); choose a different pin",
-                 pin);
-        return true;
-    }
-#else
-    (void)pin;
-    (void)result;
-    (void)result_len;
-#endif
-    return false;
-}
 
 static bool gpio_append_read_state(char **cursor, size_t *remaining, int pin, bool first_pin)
 {
@@ -141,8 +56,8 @@ bool tools_gpio_write_handler(const cJSON *input, char *result, size_t result_le
     int pin = pin_json->valueint;
     int state = state_json->valueint;
 
-    if (!gpio_pin_is_allowed(pin)) {
-        if (gpio_pin_forbidden_hint(pin, result, result_len)) {
+    if (!gpio_policy_pin_is_allowed(pin)) {
+        if (gpio_policy_pin_forbidden_hint(pin, result, result_len)) {
             return false;
         }
         if (GPIO_ALLOWED_PINS_CSV[0] != '\0') {
@@ -174,8 +89,8 @@ bool tools_gpio_read_handler(const cJSON *input, char *result, size_t result_len
 
     int pin = pin_json->valueint;
 
-    if (!gpio_pin_is_allowed(pin)) {
-        if (gpio_pin_forbidden_hint(pin, result, result_len)) {
+    if (!gpio_policy_pin_is_allowed(pin)) {
+        if (gpio_policy_pin_forbidden_hint(pin, result, result_len)) {
             return false;
         }
         if (GPIO_ALLOWED_PINS_CSV[0] != '\0') {
@@ -242,7 +157,7 @@ bool tools_gpio_read_all_handler(const cJSON *input, char *result, size_t result
                 csv_cursor = endptr;
                 continue;
             }
-            if (!gpio_pin_is_allowed((int)value)) {
+            if (!gpio_policy_pin_is_allowed((int)value)) {
                 csv_cursor = endptr;
                 continue;
             }
@@ -257,7 +172,7 @@ bool tools_gpio_read_all_handler(const cJSON *input, char *result, size_t result
     } else {
         int pin;
         for (pin = GPIO_MIN_PIN; pin <= GPIO_MAX_PIN; pin++) {
-            if (!gpio_pin_is_allowed(pin)) {
+            if (!gpio_policy_pin_is_allowed(pin)) {
                 continue;
             }
             if (!gpio_append_read_state(&cursor, &remaining, pin, count == 0)) {
@@ -307,23 +222,11 @@ bool tools_delay_handler(const cJSON *input, char *result, size_t result_len)
 #ifdef TEST_BUILD
 bool tools_gpio_test_pin_is_allowed(int pin, const char *csv, int min_pin, int max_pin)
 {
-    if (csv && csv[0] != '\0') {
-        return gpio_pin_in_allowlist(pin, csv);
-    }
-    return pin >= min_pin && pin <= max_pin;
+    return gpio_policy_test_pin_is_allowed(pin, csv, min_pin, max_pin, false, true);
 }
 
 bool tools_gpio_test_pin_is_allowed_for_esp32_target(int pin, const char *csv, int min_pin, int max_pin)
 {
-    if (pin < 0) {
-        return false;
-    }
-    if (pin >= 6 && pin <= 11) {
-        return false;
-    }
-    if (csv && csv[0] != '\0') {
-        return gpio_pin_in_allowlist(pin, csv);
-    }
-    return pin >= min_pin && pin <= max_pin;
+    return gpio_policy_test_pin_is_allowed(pin, csv, min_pin, max_pin, true, true);
 }
 #endif

--- a/main/tools_i2c.c
+++ b/main/tools_i2c.c
@@ -1,5 +1,6 @@
 #include "tools_handlers.h"
 #include "config.h"
+#include "gpio_policy.h"
 #include "driver/i2c.h"
 #include "esp_err.h"
 #include "freertos/FreeRTOS.h"
@@ -17,54 +18,12 @@
 #define I2C_SCAN_MAX_FREQ_HZ         1000000
 #define I2C_SCAN_ADDR_TIMEOUT_MS     25
 
-static bool gpio_pin_in_allowlist(int pin, const char *csv)
-{
-    const char *cursor;
-
-    if (!csv || csv[0] == '\0') {
-        return false;
-    }
-
-    cursor = csv;
-    while (*cursor != '\0') {
-        char *endptr = NULL;
-        long value;
-
-        while (*cursor == ' ' || *cursor == '\t' || *cursor == ',') {
-            cursor++;
-        }
-        if (*cursor == '\0') {
-            break;
-        }
-
-        value = strtol(cursor, &endptr, 10);
-        if (endptr == cursor) {
-            while (*cursor != '\0' && *cursor != ',') {
-                cursor++;
-            }
-            continue;
-        }
-
-        if ((int)value == pin) {
-            return true;
-        }
-        cursor = endptr;
-    }
-
-    return false;
-}
-
-static bool gpio_pin_is_allowed(int pin)
-{
-    if (GPIO_ALLOWED_PINS_CSV[0] != '\0') {
-        return gpio_pin_in_allowlist(pin, GPIO_ALLOWED_PINS_CSV);
-    }
-    return pin >= GPIO_MIN_PIN && pin <= GPIO_MAX_PIN;
-}
-
 static bool validate_scan_pin(const char *field_name, int pin, char *result, size_t result_len)
 {
-    if (!gpio_pin_is_allowed(pin)) {
+    if (!gpio_policy_pin_is_allowed(pin)) {
+        if (gpio_policy_pin_forbidden_hint(pin, result, result_len)) {
+            return false;
+        }
         if (GPIO_ALLOWED_PINS_CSV[0] != '\0') {
             snprintf(result, result_len, "Error: %s pin %d is not in allowed list", field_name, pin);
         } else {
@@ -229,3 +188,10 @@ bool tools_i2c_scan_handler(const cJSON *input, char *result, size_t result_len)
 
     return true;
 }
+
+#ifdef TEST_BUILD
+bool tools_i2c_test_pin_is_allowed_for_esp32_target(int pin, const char *csv, int min_pin, int max_pin)
+{
+    return gpio_policy_test_pin_is_allowed(pin, csv, min_pin, max_pin, true, true);
+}
+#endif

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -61,6 +61,7 @@ run_host_tests() {
         test_telegram_poll_policy.c \
         test_agent.c \
         test_tools_gpio_policy.c \
+        test_tools_i2c_policy.c \
         test_builtin_tools_registry.c \
         test_tools_system_diag.c \
         test_llm_auth.c \
@@ -74,6 +75,7 @@ run_host_tests() {
         mock_tools.c \
         mock_system_diag_deps.c \
         mock_ratelimit.c \
+        mock_i2c.c \
         ../../main/json_util.c \
         ../../main/cron_utils.c \
         ../../main/security.c \
@@ -87,7 +89,9 @@ run_host_tests() {
         ../../main/telegram_chat_ids.c \
         ../../main/telegram_poll_policy.c \
         ../../main/agent.c \
+        ../../main/gpio_policy.c \
         ../../main/tools_gpio.c \
+        ../../main/tools_i2c.c \
         ../../main/tools_system.c \
         $CJSON_LDFLAGS 2>&1 || {
         echo "Note: Failed to compile tests. Install cJSON:"

--- a/test/host/driver/gpio.h
+++ b/test/host/driver/gpio.h
@@ -6,6 +6,7 @@ typedef int gpio_num_t;
 #define GPIO_MODE_OUTPUT 1
 #define GPIO_MODE_INPUT 2
 #define GPIO_MODE_INPUT_OUTPUT (GPIO_MODE_OUTPUT | GPIO_MODE_INPUT)
+#define GPIO_IS_VALID_GPIO(pin) ((pin) >= 0 && (pin) < GPIO_TEST_PIN_LIMIT)
 
 enum {
     GPIO_TEST_PIN_LIMIT = 128,

--- a/test/host/driver/i2c.h
+++ b/test/host/driver/i2c.h
@@ -1,0 +1,43 @@
+#ifndef DRIVER_I2C_H
+#define DRIVER_I2C_H
+
+#include "esp_err.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef int i2c_port_t;
+typedef void *i2c_cmd_handle_t;
+
+typedef struct {
+    int mode;
+    int sda_io_num;
+    int scl_io_num;
+    int sda_pullup_en;
+    int scl_pullup_en;
+    struct {
+        int clk_speed;
+    } master;
+} i2c_config_t;
+
+#define I2C_NUM_0 0
+#define I2C_MODE_MASTER 1
+#define I2C_MASTER_WRITE 0
+#define GPIO_PULLUP_ENABLE 1
+
+esp_err_t i2c_param_config(i2c_port_t i2c_num, const i2c_config_t *i2c_conf);
+esp_err_t i2c_driver_install(i2c_port_t i2c_num, int mode, int slv_rx_buf_len, int slv_tx_buf_len, int intr_alloc_flags);
+esp_err_t i2c_driver_delete(i2c_port_t i2c_num);
+i2c_cmd_handle_t i2c_cmd_link_create(void);
+void i2c_cmd_link_delete(i2c_cmd_handle_t cmd_handle);
+esp_err_t i2c_master_start(i2c_cmd_handle_t cmd_handle);
+esp_err_t i2c_master_write_byte(i2c_cmd_handle_t cmd_handle, uint8_t data, bool ack_en);
+esp_err_t i2c_master_stop(i2c_cmd_handle_t cmd_handle);
+esp_err_t i2c_master_cmd_begin(i2c_port_t i2c_num, i2c_cmd_handle_t cmd_handle, uint32_t ticks_to_wait);
+
+void i2c_test_reset(void);
+void i2c_test_set_cmd_begin_result(esp_err_t result);
+int i2c_test_get_param_config_calls(void);
+int i2c_test_get_driver_install_calls(void);
+int i2c_test_get_driver_delete_calls(void);
+
+#endif  // DRIVER_I2C_H

--- a/test/host/mock_i2c.c
+++ b/test/host/mock_i2c.c
@@ -1,0 +1,100 @@
+#include "driver/i2c.h"
+
+#include <stddef.h>
+
+static int s_param_config_calls = 0;
+static int s_driver_install_calls = 0;
+static int s_driver_delete_calls = 0;
+static esp_err_t s_cmd_begin_result = ESP_FAIL;
+
+void i2c_test_reset(void)
+{
+    s_param_config_calls = 0;
+    s_driver_install_calls = 0;
+    s_driver_delete_calls = 0;
+    s_cmd_begin_result = ESP_FAIL;
+}
+
+void i2c_test_set_cmd_begin_result(esp_err_t result)
+{
+    s_cmd_begin_result = result;
+}
+
+int i2c_test_get_param_config_calls(void)
+{
+    return s_param_config_calls;
+}
+
+int i2c_test_get_driver_install_calls(void)
+{
+    return s_driver_install_calls;
+}
+
+int i2c_test_get_driver_delete_calls(void)
+{
+    return s_driver_delete_calls;
+}
+
+esp_err_t i2c_param_config(i2c_port_t i2c_num, const i2c_config_t *i2c_conf)
+{
+    (void)i2c_num;
+    (void)i2c_conf;
+    s_param_config_calls++;
+    return ESP_OK;
+}
+
+esp_err_t i2c_driver_install(i2c_port_t i2c_num, int mode, int slv_rx_buf_len, int slv_tx_buf_len, int intr_alloc_flags)
+{
+    (void)i2c_num;
+    (void)mode;
+    (void)slv_rx_buf_len;
+    (void)slv_tx_buf_len;
+    (void)intr_alloc_flags;
+    s_driver_install_calls++;
+    return ESP_OK;
+}
+
+esp_err_t i2c_driver_delete(i2c_port_t i2c_num)
+{
+    (void)i2c_num;
+    s_driver_delete_calls++;
+    return ESP_OK;
+}
+
+i2c_cmd_handle_t i2c_cmd_link_create(void)
+{
+    return (i2c_cmd_handle_t)1;
+}
+
+void i2c_cmd_link_delete(i2c_cmd_handle_t cmd_handle)
+{
+    (void)cmd_handle;
+}
+
+esp_err_t i2c_master_start(i2c_cmd_handle_t cmd_handle)
+{
+    (void)cmd_handle;
+    return ESP_OK;
+}
+
+esp_err_t i2c_master_write_byte(i2c_cmd_handle_t cmd_handle, uint8_t data, bool ack_en)
+{
+    (void)cmd_handle;
+    (void)data;
+    (void)ack_en;
+    return ESP_OK;
+}
+
+esp_err_t i2c_master_stop(i2c_cmd_handle_t cmd_handle)
+{
+    (void)cmd_handle;
+    return ESP_OK;
+}
+
+esp_err_t i2c_master_cmd_begin(i2c_port_t i2c_num, i2c_cmd_handle_t cmd_handle, uint32_t ticks_to_wait)
+{
+    (void)i2c_num;
+    (void)cmd_handle;
+    (void)ticks_to_wait;
+    return s_cmd_begin_result;
+}

--- a/test/host/test_runner.c
+++ b/test/host/test_runner.c
@@ -18,6 +18,7 @@ extern int test_telegram_chat_ids_all(void);
 extern int test_telegram_poll_policy_all(void);
 extern int test_agent_all(void);
 extern int test_tools_gpio_policy_all(void);
+extern int test_tools_i2c_policy_all(void);
 extern int test_builtin_tools_registry_all(void);
 extern int test_tools_system_diag_all(void);
 extern int test_llm_auth_all(void);
@@ -43,6 +44,7 @@ int main(int argc, char *argv[])
     failures += test_telegram_poll_policy_all();
     failures += test_agent_all();
     failures += test_tools_gpio_policy_all();
+    failures += test_tools_i2c_policy_all();
     failures += test_builtin_tools_registry_all();
     failures += test_tools_system_diag_all();
     failures += test_llm_auth_all();

--- a/test/host/test_tools_i2c_policy.c
+++ b/test/host/test_tools_i2c_policy.c
@@ -1,0 +1,102 @@
+/*
+ * Host tests for i2c_scan pin policy and initialization behavior.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <cjson/cJSON.h>
+
+#include "driver/i2c.h"
+#include "tools_handlers.h"
+
+#define TEST(name) static int test_##name(void)
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        printf("  FAIL: %s (line %d)\n", #cond, __LINE__); \
+        return 1; \
+    } \
+} while (0)
+#define ASSERT_STR_CONTAINS(haystack, needle) do { \
+    if (strstr((haystack), (needle)) == NULL) { \
+        printf("  FAIL: expected substring '%s' in '%s' (line %d)\n", (needle), (haystack), __LINE__); \
+        return 1; \
+    } \
+} while (0)
+
+bool tools_i2c_test_pin_is_allowed_for_esp32_target(int pin, const char *csv, int min_pin, int max_pin);
+
+TEST(esp32_target_blocks_flash_pins_for_i2c_policy)
+{
+    ASSERT(tools_i2c_test_pin_is_allowed_for_esp32_target(5, "", 2, 12));
+    ASSERT(!tools_i2c_test_pin_is_allowed_for_esp32_target(6, "", 2, 12));
+    ASSERT(!tools_i2c_test_pin_is_allowed_for_esp32_target(11, "", 2, 12));
+    ASSERT(tools_i2c_test_pin_is_allowed_for_esp32_target(12, "", 2, 12));
+    return 0;
+}
+
+TEST(rejects_disallowed_pin_before_i2c_init)
+{
+    cJSON *input = cJSON_Parse("{\"sda_pin\":1,\"scl_pin\":2}");
+    char result[256] = {0};
+
+    ASSERT(input != NULL);
+    i2c_test_reset();
+
+    ASSERT(!tools_i2c_scan_handler(input, result, sizeof(result)));
+    ASSERT_STR_CONTAINS(result, "SDA pin");
+    ASSERT(i2c_test_get_param_config_calls() == 0);
+    ASSERT(i2c_test_get_driver_install_calls() == 0);
+
+    cJSON_Delete(input);
+    return 0;
+}
+
+TEST(valid_scan_path_initializes_i2c_and_returns_no_devices)
+{
+    cJSON *input = cJSON_Parse("{\"sda_pin\":4,\"scl_pin\":5,\"frequency_hz\":100000}");
+    char result[256] = {0};
+
+    ASSERT(input != NULL);
+    i2c_test_reset();
+    i2c_test_set_cmd_begin_result(ESP_FAIL);
+
+    ASSERT(tools_i2c_scan_handler(input, result, sizeof(result)));
+    ASSERT_STR_CONTAINS(result, "No I2C devices found");
+    ASSERT(i2c_test_get_param_config_calls() == 1);
+    ASSERT(i2c_test_get_driver_install_calls() == 1);
+    ASSERT(i2c_test_get_driver_delete_calls() >= 2);
+
+    cJSON_Delete(input);
+    return 0;
+}
+
+int test_tools_i2c_policy_all(void)
+{
+    int failures = 0;
+
+    printf("\nI2C Policy Tests:\n");
+
+    printf("  esp32_target_blocks_flash_pins_for_i2c_policy... ");
+    if (test_esp32_target_blocks_flash_pins_for_i2c_policy() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  rejects_disallowed_pin_before_i2c_init... ");
+    if (test_rejects_disallowed_pin_before_i2c_init() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  valid_scan_path_initializes_i2c_and_returns_no_devices... ");
+    if (test_valid_scan_path_initializes_i2c_and_returns_no_devices() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    return failures;
+}


### PR DESCRIPTION
## Summary
- factor GPIO/I2C pin checks into a shared gpio_policy module
- apply shared policy to tools_i2c_scan_handler so it matches GPIO tool safety behavior
- keep GPIO behavior unchanged while deduplicating policy logic
- add host I2C mocks/tests to validate pin rejection before init and happy-path scan init

## Validation
- ./scripts/test.sh host
- 20x host soak of test/host/build/test_runner
- firmware build for esp32s3
