### PR TITLE
provision: add model selection prompt

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -950,7 +950,13 @@ if ! validate_backend "$BACKEND"; then
 fi
 
 if [ -z "$MODEL" ]; then
-    MODEL="$(default_model_for_backend "$BACKEND")"
+    DEFAULT_MODEL="$(default_model_for_backend "$BACKEND")"
+    if [ "$ASSUME_YES" = true ]; then
+        MODEL="$DEFAULT_MODEL"
+    else
+        read -r -p "Model ID (default: $DEFAULT_MODEL): " MODEL
+        MODEL="${MODEL:-$DEFAULT_MODEL}"
+    fi
 fi
 
 if [ "$BACKEND" = "ollama" ]; then


### PR DESCRIPTION
Make model selection interactive in `provision.sh` when no `--model` argument is provided. Previously, it silently fell back to the default model for the selected backend. Now it prompts the user, offering the default as a suggestion. 
Maintains the silent fallback behavior for non-interactive (`--yes`) mode.