### PR TITLE
fix: make sidebar links visible with reduced motion

### DIFF
--- a/docs-site/styles.css
+++ b/docs-site/styles.css
@@ -648,6 +648,9 @@ kbd {
     animation: none !important;
     transition: none !important;
   }
+  .chapter-list li {
+    opacity: 1 !important;
+  }
 }
 
 @media (max-width: 980px) {


### PR DESCRIPTION
issue: the titles of the side bar don't show when the theme is not "br"
---
the current ui
<img width="1200" alt="11475" src="https://github.com/user-attachments/assets/3afe8340-6e93-4984-9fe3-c04a836a196a" />

what I fixed:
<img width="1200" alt="58096" src="https://github.com/user-attachments/assets/1a35699b-e809-42e4-a149-3932b81c00f0" />
