### PR TITLE
Ignore generated build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,17 @@
 build/
 build-qemu/
 build-secure/
+/build-*/
+/build.*/
 sdkconfig
 sdkconfig.qemu
 sdkconfig.old
+/sdkconfig.*
+!/sdkconfig.defaults
+!/sdkconfig.qemu.defaults
+!/sdkconfig.*.defaults
+!/sdkconfig.secure
+!/sdkconfig.test
 
 # Flash encryption keys (NEVER commit these!)
 keys/


### PR DESCRIPTION
## Summary
- ignore generated root-level `build-*` and `build.*` directories
- ignore local `sdkconfig.*` variants while keeping tracked defaults and checked-in config files visible
- reduce `git status` noise from local ESP-IDF build outputs

## Verification
- confirmed `git status --short` is clean on the branch after removing the stray local `ideas` file