### PR TITLE
Add USB local admin console

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Fun to use, fun to hack on.
 Use the docs site for complete guides and reference.
 
 - [Full documentation](https://zclaw.dev)
+- [Local Admin Console](https://zclaw.dev/local-admin.html)
 - [Use cases: useful + fun](https://zclaw.dev/use-cases.html)
 - [Changelog (web)](https://zclaw.dev/changelog.html)
 - [Complete README (verbatim)](https://zclaw.dev/reference/README_COMPLETE.md)
@@ -71,6 +72,7 @@ Non-interactive install:
 - For brand-new built-in capabilities, add a firmware tool (C handler + registry entry) via the Build Your Own Tool docs.
 - Runtime diagnostics via `get_diagnostics` (quick/runtime/memory/rates/time/all scopes)
 - GPIO read/write control with guardrails (including bulk `gpio_read_all`)
+- USB local admin console for recovery, safe mode, and pre-network bring-up
 - Persistent memory across reboots
 - Persona options: `neutral`, `friendly`, `technical`, `witty`
 - Provider support for Anthropic, OpenAI, OpenRouter, and Ollama (custom endpoint)
@@ -128,19 +130,44 @@ More details in the [Local Dev & Hacking guide](https://zclaw.dev/local-dev.html
 
 </details>
 
+## Local Admin Console
+
+When the board is in safe mode, unprovisioned, or the LLM path is unavailable, you can still operate it over USB serial without Wi-Fi or an LLM round trip.
+
+```bash
+./scripts/monitor.sh /dev/cu.usbmodem1101
+# then type:
+/wifi status
+/wifi scan
+/bootcount
+/gpio all
+/reboot
+```
+
+Available local-only commands:
+
+- `/gpio [all|pin|pin high|pin low]`
+- `/diag [scope] [verbose]`
+- `/reboot`
+- `/wifi [status|scan]`
+- `/bootcount`
+- `/factory-reset confirm` (destructive; wipes NVS and reboots)
+
+Full reference: [Local Admin Console](https://zclaw.dev/local-admin.html)
+
 ## Size Breakdown
 
-Current default `esp32s3` breakdown (grouped loadable image bytes from `idf.py -B build size-components`; rows sum to total image size):
+Current default `esp32` breakdown (grouped image bytes from `idf.py -B build size-components`):
 
 | Segment | Bytes | Size | Share |
 | --- | ---: | ---: | ---: |
-| zclaw app logic (`libmain.a`) | `35742` | ~34.9 KiB | ~4.1% |
-| Wi-Fi + networking stack | `397356` | ~388.0 KiB | ~45.7% |
-| TLS/crypto stack | `112922` | ~110.3 KiB | ~13.0% |
-| cert bundle + app metadata | `99722` | ~97.4 KiB | ~11.5% |
-| other ESP-IDF/runtime/drivers/libc | `224096` | ~218.8 KiB | ~25.8% |
+| zclaw app logic (`libmain.a`) | `39276` | ~38.4 KiB | ~4.6% |
+| Wi-Fi + networking stack | `378624` | ~369.8 KiB | ~44.4% |
+| TLS/crypto stack | `134923` | ~131.8 KiB | ~15.8% |
+| cert bundle + app metadata | `98425` | ~96.1 KiB | ~11.5% |
+| other ESP-IDF/runtime/drivers/libc | `201786` | ~197.1 KiB | ~23.7% |
 
-Total image size from this build is `869838` bytes; padded `zclaw.bin` is `869952` bytes (~849.6 KiB), still under the cap.
+Total image size from this build is `853034` bytes; padded `zclaw.bin` is `853184` bytes (~833.2 KiB), leaving `56128` bytes (~54.8 KiB) under the 888 KiB cap.
 
 ## Latency Benchmarking
 

--- a/docs-site/README.html
+++ b/docs-site/README.html
@@ -191,24 +191,25 @@
           <img src="images/lobster_xiao_cropped_left.png" alt="Lobster soldering a Seeed Studio XIAO ESP32-C3">
         </section>
 
-        <p>Current default <code>esp32s3</code> breakdown (<code>idf.py -B build size-components</code>, flash totals):</p>
+        <p>Current default <code>esp32</code> breakdown (<code>idf.py -B build size-components</code>, grouped image bytes):</p>
         <table>
           <thead>
             <tr><th>Layer</th><th>Size</th><th>Share</th></tr>
           </thead>
           <tbody>
-            <tr><td>zclaw app logic (<code>libmain.a</code>)</td><td>26,430 bytes (~25.8 KiB)</td><td>~3.1%</td></tr>
-            <tr><td>Wi-Fi + networking stack</td><td>375,278 bytes (~366.5 KiB)</td><td>~43.7%</td></tr>
-            <tr><td>TLS/crypto stack</td><td>125,701 bytes (~122.8 KiB)</td><td>~14.7%</td></tr>
-            <tr><td>Cert bundle + app metadata</td><td>92,654 bytes (~90.5 KiB)</td><td>~10.8%</td></tr>
-            <tr><td>Other ESP-IDF/runtime/drivers/libc</td><td>237,889 bytes (~232.3 KiB)</td><td>~27.7%</td></tr>
+            <tr><td>zclaw app logic (<code>libmain.a</code>)</td><td>39,276 bytes (~38.4 KiB)</td><td>~4.6%</td></tr>
+            <tr><td>Wi-Fi + networking stack</td><td>378,624 bytes (~369.8 KiB)</td><td>~44.4%</td></tr>
+            <tr><td>TLS/crypto stack</td><td>134,923 bytes (~131.8 KiB)</td><td>~15.8%</td></tr>
+            <tr><td>Cert bundle + app metadata</td><td>98,425 bytes (~96.1 KiB)</td><td>~11.5%</td></tr>
+            <tr><td>Other ESP-IDF/runtime/drivers/libc</td><td>201,786 bytes (~197.1 KiB)</td><td>~23.7%</td></tr>
           </tbody>
         </table>
-        <p><code>zclaw.bin</code> from the same build is <strong>865,888 bytes</strong> (~845.6 KiB), under the 888 KiB cap.</p>
+        <p><code>zclaw.bin</code> from the same build is <strong>853,184 bytes</strong> (~833.2 KiB), leaving <strong>56,128 bytes</strong> (~54.8 KiB) under the 888 KiB cap.</p>
 
         <h2>Full Documentation</h2>
         <ul>
           <li><a href="index.html">Full docs site</a></li>
+          <li><a href="local-admin.html">Local Admin Console</a></li>
           <li><a href="reference/README_COMPLETE.md">Complete README (verbatim, full detail)</a></li>
         </ul>
 
@@ -230,6 +231,7 @@ bash &lt;(curl -fsSL https://raw.githubusercontent.com/tnm/zclaw/main/scripts/bo
           <li>After flashing, provision WiFi + LLM credentials with <code>./scripts/provision.sh</code>.</li>
           <li>For Ollama, run it on a LAN-reachable host and pass <code>--backend ollama --api-url http://&lt;host&gt;:11434</code> during provisioning.</li>
           <li>Telegram control commands: <code>/start</code> and <code>/help</code> show help, <code>/settings</code> shows bot status, <code>/stop</code> pauses message intake, <code>/resume</code> re-enables message intake.</li>
+          <li>USB local admin commands: <code>/gpio</code>, <code>/diag</code>, <code>/reboot</code>, <code>/wifi</code>, <code>/bootcount</code>, and <code>/factory-reset confirm</code> work without the LLM path.</li>
           <li>If serial port is busy, run <code>./scripts/release-port.sh</code> and retry.</li>
           <li>Full setup/provisioning details are in the docs site index.</li>
         </ul>
@@ -240,6 +242,7 @@ bash &lt;(curl -fsSL https://raw.githubusercontent.com/tnm/zclaw/main/scripts/bo
           <li>Timezone-aware schedules (<code>daily</code>, <code>periodic</code>, and one-shot <code>once</code>)</li>
           <li>Built-in + user-defined tools</li>
           <li>GPIO read/write control with guardrails</li>
+          <li>USB local admin console for recovery and safe mode</li>
           <li>Persistent memory across reboots</li>
           <li>Provider support for Anthropic, OpenAI, OpenRouter, and Ollama (custom endpoint)</li>
         </ul>
@@ -266,6 +269,16 @@ bash &lt;(curl -fsSL https://raw.githubusercontent.com/tnm/zclaw/main/scripts/bo
             <tr><td><code>./scripts/test.sh</code></td><td>Run host/device test flows</td></tr>
           </tbody>
         </table>
+
+        <h2>Local Admin Console</h2>
+        <p>When the board is in safe mode, unprovisioned, or the network path is broken, use the USB console for local admin commands.</p>
+        <pre><code>./scripts/monitor.sh /dev/cu.usbmodem1101
+/wifi status
+/wifi scan
+/bootcount
+/gpio all
+/reboot</code></pre>
+        <p>See <a href="local-admin.html">Chapter 9 · Local Admin Console</a> for the full command reference and the destructive reset path.</p>
 
         <h2>License</h2>
         <p>MIT</p>

--- a/docs-site/architecture.html
+++ b/docs-site/architecture.html
@@ -36,6 +36,7 @@
           <li><a href="local-dev.html">Chapter 6 · Local Dev &amp; Hacking</a></li>
           <li><a href="use-cases.html">Chapter 7 · Use Cases</a></li>
           <li><a href="changelog.html">Chapter 8 · Changelog</a></li>
+          <li><a href="local-admin.html">Chapter 9 · Local Admin Console</a></li>
         </ul>
       </aside>
 

--- a/docs-site/build-your-own-tool.html
+++ b/docs-site/build-your-own-tool.html
@@ -36,6 +36,7 @@
           <li><a href="local-dev.html">Chapter 6 · Local Dev &amp; Hacking</a></li>
           <li><a href="use-cases.html">Chapter 7 · Use Cases</a></li>
           <li><a href="changelog.html">Chapter 8 · Changelog</a></li>
+          <li><a href="local-admin.html">Chapter 9 · Local Admin Console</a></li>
         </ul>
       </aside>
 

--- a/docs-site/changelog.html
+++ b/docs-site/changelog.html
@@ -36,6 +36,7 @@
           <li><a href="local-dev.html">Chapter 6 · Local Dev &amp; Hacking</a></li>
           <li><a href="use-cases.html">Chapter 7 · Use Cases</a></li>
           <li><a href="changelog.html">Chapter 8 · Changelog</a></li>
+          <li><a href="local-admin.html">Chapter 9 · Local Admin Console</a></li>
         </ul>
       </aside>
 

--- a/docs-site/getting-started.html
+++ b/docs-site/getting-started.html
@@ -36,6 +36,7 @@
           <li><a href="local-dev.html">Chapter 6 · Local Dev &amp; Hacking</a></li>
           <li><a href="use-cases.html">Chapter 7 · Use Cases</a></li>
           <li><a href="changelog.html">Chapter 8 · Changelog</a></li>
+          <li><a href="local-admin.html">Chapter 9 · Local Admin Console</a></li>
         </ul>
       </aside>
 
@@ -240,6 +241,7 @@ cd ~/esp/esp-idf
 # Build/test routines
 ./scripts/build.sh
 ./scripts/test.sh host</pre>
+          <p class="inline-note">For safe-mode recovery and pre-network board checks, use the USB local admin console in <a href="local-admin.html">Chapter 9</a>.</p>
         </section>
 
         <section class="section">

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -36,6 +36,7 @@
           <li><a href="local-dev.html">Chapter 6 · Local Dev &amp; Hacking</a></li>
           <li><a href="use-cases.html">Chapter 7 · Use Cases</a></li>
           <li><a href="changelog.html">Chapter 8 · Changelog</a></li>
+          <li><a href="local-admin.html">Chapter 9 · Local Admin Console</a></li>
         </ul>
         <p class="sidebar-note">Practical notes for building, flashing, and operating zclaw in the field.</p>
       </aside>
@@ -77,20 +78,20 @@ Agent: Created schedule #7: once in 20 min -> check the garage sensor</pre>
         <section class="section">
           <h2>What "888 KiB" Means</h2>
           <p>The <strong>888 KiB</strong> target is an all-in firmware cap, not just zclaw application logic. It includes app code plus ESP-IDF/FreeRTOS runtime, Wi-Fi/networking, TLS/crypto, and cert bundle overhead.</p>
-          <p>Current default <code>esp32s3</code> build (grouped loadable image bytes from <code>idf.py -B build size-components</code>; rows sum to total image size):</p>
+          <p>Current default <code>esp32</code> build (grouped image bytes from <code>idf.py -B build size-components</code>):</p>
           <table>
             <thead>
               <tr><th>Layer</th><th>Size</th><th>Share</th></tr>
             </thead>
             <tbody>
-              <tr><td>zclaw app logic (<code>libmain.a</code>)</td><td>35,742 bytes (~34.9 KiB)</td><td>~4.1%</td></tr>
-              <tr><td>Wi-Fi + networking stack</td><td>397,356 bytes (~388.0 KiB)</td><td>~45.7%</td></tr>
-              <tr><td>TLS/crypto stack</td><td>112,922 bytes (~110.3 KiB)</td><td>~13.0%</td></tr>
-              <tr><td>Cert bundle + app metadata</td><td>99,722 bytes (~97.4 KiB)</td><td>~11.5%</td></tr>
-              <tr><td>Other ESP-IDF/runtime/drivers/libc</td><td>224,096 bytes (~218.8 KiB)</td><td>~25.8%</td></tr>
+              <tr><td>zclaw app logic (<code>libmain.a</code>)</td><td>39,276 bytes (~38.4 KiB)</td><td>~4.6%</td></tr>
+              <tr><td>Wi-Fi + networking stack</td><td>378,624 bytes (~369.8 KiB)</td><td>~44.4%</td></tr>
+              <tr><td>TLS/crypto stack</td><td>134,923 bytes (~131.8 KiB)</td><td>~15.8%</td></tr>
+              <tr><td>Cert bundle + app metadata</td><td>98,425 bytes (~96.1 KiB)</td><td>~11.5%</td></tr>
+              <tr><td>Other ESP-IDF/runtime/drivers/libc</td><td>201,786 bytes (~197.1 KiB)</td><td>~23.7%</td></tr>
             </tbody>
           </table>
-          <p class="inline-note">Total image size from this build is <strong>869,838 bytes</strong>; padded <code>zclaw.bin</code> is <strong>869,952 bytes</strong> (~849.6 KiB), under the 888 KiB cap.</p>
+          <p class="inline-note">Total image size from this build is <strong>853,034 bytes</strong>; padded <code>zclaw.bin</code> is <strong>853,184 bytes</strong> (~833.2 KiB), leaving <strong>56,128 bytes</strong> (~54.8 KiB) under the 888 KiB cap.</p>
         </section>
 
         <section class="section">
@@ -128,6 +129,10 @@ Agent: Created schedule #7: once in 20 min -> check the garage sensor</pre>
               <strong>Chapter 8 · Changelog</strong>
               <span>Release notes and a timeline of what changed across versions.</span>
             </a>
+            <a class="chapter-link" href="local-admin.html">
+              <strong>Chapter 9 · Local Admin Console</strong>
+              <span>USB-local recovery and bring-up commands that work without Wi-Fi or the LLM.</span>
+            </a>
           </div>
         </section>
 
@@ -137,6 +142,7 @@ Agent: Created schedule #7: once in 20 min -> check the garage sensor</pre>
             <li><strong>Language/runtime:</strong> C + ESP-IDF + FreeRTOS.</li>
             <li><strong>LLM backends:</strong> Anthropic, OpenAI, OpenRouter, Ollama (custom endpoint).</li>
             <li><strong>Interface:</strong> Telegram and optional host web relay.</li>
+            <li><strong>Recovery plane:</strong> USB local admin commands keep the board operable in safe mode and before network bring-up.</li>
             <li><strong>Philosophy:</strong> ship useful automation under strict resource bounds.</li>
           </ul>
         </section>

--- a/docs-site/local-admin.html
+++ b/docs-site/local-admin.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="zclaw Field Guide: USB-local admin commands for recovery, safe mode, and pre-network bring-up.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="zclaw - Field Guide">
+    <meta property="og:title" content="zclaw - Field Guide | Local Admin Console">
+    <meta property="og:description" content="USB-local admin commands for recovery, safe mode, and pre-network bring-up.">
+    <meta property="og:image" content="https://zclaw.dev/images/lobster_xiao_cropped_left.png">
+    <meta property="og:image:alt" content="Lobster soldering a Seeed Studio XIAO ESP32-C3">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="zclaw - Field Guide | Local Admin Console">
+    <meta name="twitter:description" content="USB-local admin commands for recovery, safe mode, and pre-network bring-up.">
+    <meta name="twitter:image" content="https://zclaw.dev/images/lobster_xiao_cropped_left.png">
+    <title>zclaw - Field Guide | Local Admin Console</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <div class="page">
+      <aside class="sidebar">
+        <div class="brand">
+          <h1>zclaw</h1>
+          <p>Field Guide</p>
+        </div>
+        <div class="divider"></div>
+        <ul class="chapter-list">
+          <li><a href="index.html">Chapter 0 · Overview</a></li>
+          <li><a href="getting-started.html">Chapter 1 · Getting Started</a></li>
+          <li><a href="tools.html">Chapter 2 · Tool Surface</a></li>
+          <li><a href="architecture.html">Chapter 3 · Runtime Anatomy</a></li>
+          <li><a href="security.html">Chapter 4 · Security &amp; Ops</a></li>
+          <li><a href="build-your-own-tool.html">Chapter 5 · Build Your Own Tool</a></li>
+          <li><a href="local-dev.html">Chapter 6 · Local Dev &amp; Hacking</a></li>
+          <li><a href="use-cases.html">Chapter 7 · Use Cases</a></li>
+          <li><a href="changelog.html">Chapter 8 · Changelog</a></li>
+          <li><a href="local-admin.html">Chapter 9 · Local Admin Console</a></li>
+        </ul>
+      </aside>
+
+      <main class="content-wrap">
+        <div class="topbar">
+          <p class="kicker">zclaw docs</p>
+          <div class="topbar-actions">
+            <button class="menu-toggle" type="button" aria-label="Open chapter menu">☰</button>
+          </div>
+        </div>
+
+        <header>
+          <p class="kicker">chapter 9</p>
+          <h1 class="page-title">Local Admin Console</h1>
+          <p class="deck">USB-local recovery commands for when Wi-Fi is broken, the board is unprovisioned, or the LLM path is unavailable.</p>
+        </header>
+
+        <section class="section">
+          <h2>Why This Exists</h2>
+          <p>The local admin console is the board's non-LLM control plane. It keeps zclaw operable when chat automation is the wrong tool for the job: first boot, provisioning mistakes, weak Wi-Fi, safe mode, or general field recovery.</p>
+          <ul>
+            <li>It runs over the USB serial console.</li>
+            <li>It does not require a Wi-Fi connection.</li>
+            <li>It does not require an LLM round trip.</li>
+            <li>It stays available in safe mode and before normal network startup.</li>
+          </ul>
+        </section>
+
+        <section class="section">
+          <h2>How To Use It</h2>
+          <p>Connect the board over USB and open the serial console:</p>
+          <pre><code>./scripts/monitor.sh /dev/cu.usbmodem1101</code></pre>
+          <p>Then type commands directly into the console:</p>
+          <pre><code>/wifi status
+/wifi scan
+/bootcount
+/gpio all
+/diag all
+/reboot</code></pre>
+          <p class="inline-note">The serial benchmark helper also works well for scripted checks: <code>./scripts/benchmark.sh --mode serial --serial-port /dev/cu.usbmodem1101 --message "/wifi status"</code>.</p>
+        </section>
+
+        <section class="section">
+          <h2>Command Reference</h2>
+          <table>
+            <thead>
+              <tr><th>Command</th><th>Purpose</th><th>Notes</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>/gpio [all|pin|pin high|pin low]</code></td><td>Read or drive tool-allowed GPIO pins locally.</td><td>Respects the configured GPIO safety policy.</td></tr>
+              <tr><td><code>/diag [scope] [verbose]</code></td><td>Run local runtime diagnostics.</td><td>Scopes match <code>get_diagnostics</code>: <code>quick</code>, <code>runtime</code>, <code>memory</code>, <code>rates</code>, <code>time</code>, <code>all</code>.</td></tr>
+              <tr><td><code>/wifi status</code></td><td>Show provisioned SSID, driver/link state, IP, RSSI, and last disconnect reason.</td><td>Useful before and after scans, reprovisioning, or recovery boots.</td></tr>
+              <tr><td><code>/wifi scan</code></td><td>Scan visible Wi-Fi APs.</td><td>Lists RSSI, auth mode, channel, and frequency for the top visible networks.</td></tr>
+              <tr><td><code>/bootcount</code></td><td>Show persisted boot-failure count and safe-mode threshold state.</td><td>Helps explain why the board entered safe mode.</td></tr>
+              <tr><td><code>/reboot</code></td><td>Reboot the board immediately.</td><td>Replies once, then restarts.</td></tr>
+              <tr><td><code>/factory-reset</code></td><td>Show the destructive reset warning.</td><td>Non-destructive by itself.</td></tr>
+              <tr><td><code>/factory-reset confirm</code></td><td>Erase NVS and reboot.</td><td>Destructive: wipes Wi-Fi credentials, tokens, schedules, memory, and boot state.</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="section">
+          <h2>Availability Rules</h2>
+          <ul>
+            <li>These commands are USB-local only.</li>
+            <li>Telegram and web relay callers are rejected instead of falling through to the model.</li>
+            <li><code>/stop</code> pauses chat intake, but it does not disable local admin commands.</li>
+            <li>Safe mode keeps this console available specifically so you can inspect and recover the device.</li>
+          </ul>
+        </section>
+
+        <section class="section">
+          <h2>Safe Mode Workflow</h2>
+          <p>A typical safe-mode session looks like this:</p>
+          <pre><code>/bootcount
+/wifi status
+/wifi scan
+/diag runtime verbose
+/gpio all</code></pre>
+          <p>This is the intended recovery path: inspect boot state, inspect Wi-Fi, inspect runtime health, and only then decide whether to reprovision, move the board, or factory-reset it.</p>
+        </section>
+
+        <section class="section">
+          <h2>Destructive Reset</h2>
+          <p><code>/factory-reset confirm</code> is intentionally explicit. It erases NVS and reboots the board.</p>
+          <ul>
+            <li>Wi-Fi credentials are removed.</li>
+            <li>LLM and Telegram credentials are removed.</li>
+            <li>Schedules and persistent memory are removed.</li>
+            <li>Boot-loop state is cleared because the stored boot counter is erased.</li>
+          </ul>
+          <p class="inline-note">Use this when the stored state itself is suspect. If you only need to restart the board, use <code>/reboot</code> instead.</p>
+        </section>
+
+        <footer class="footer">
+          <p>Use this chapter as the field-recovery reference. For the firmware execution boundary behind these commands, see <a href="tools.html">Chapter 2</a>.</p>
+        </footer>
+      </main>
+    </div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/docs-site/local-dev.html
+++ b/docs-site/local-dev.html
@@ -36,6 +36,7 @@
           <li><a href="local-dev.html">Chapter 6 · Local Dev &amp; Hacking</a></li>
           <li><a href="use-cases.html">Chapter 7 · Use Cases</a></li>
           <li><a href="changelog.html">Chapter 8 · Changelog</a></li>
+          <li><a href="local-admin.html">Chapter 9 · Local Admin Console</a></li>
         </ul>
       </aside>
 

--- a/docs-site/reference/README_COMPLETE.md
+++ b/docs-site/reference/README_COMPLETE.md
@@ -146,6 +146,7 @@ Direct chapter links:
 - [Tool Reference](docs-site/tools.html)
 - [Architecture](docs-site/architecture.html)
 - [Security](docs-site/security.html)
+- [Local Admin Console](docs-site/local-admin.html)
 - [Docs site README](docs-site/README.md)
 
 ### Telegram Setup
@@ -197,6 +198,31 @@ No board yet? Run with a built-in mock responder:
 
 This relay approach does not add web UI code to ESP32 firmware binary.
 
+### Local Admin Console
+
+When the board is in safe mode, unprovisioned, or the normal network path is unavailable, you can still operate it over USB serial without Wi-Fi or an LLM round trip.
+
+```bash
+./scripts/monitor.sh /dev/cu.usbmodem1101
+# then type:
+/wifi status
+/wifi scan
+/bootcount
+/gpio all
+/reboot
+```
+
+Available local-only commands:
+
+- `/gpio [all|pin|pin high|pin low]`
+- `/diag [scope] [verbose]`
+- `/reboot`
+- `/wifi [status|scan]`
+- `/bootcount`
+- `/factory-reset confirm` (destructive; wipes NVS and reboots)
+
+Full reference: [Local Admin Console](docs-site/local-admin.html)
+
 ## Tools
 
 | Tool | Description |
@@ -235,7 +261,7 @@ Example tool call input:
 ### Runtime Diagnostics (`get_diagnostics`)
 
 `get_diagnostics` is a deeper companion to `get_health`. It supports scoped checks plus an optional `verbose` mode.
-For Telegram control-plane checks without an LLM round trip, use `/diag [scope] [verbose]`.
+For USB-local diagnostics without an LLM round trip, use `/diag [scope] [verbose]` on the serial console.
 
 - `scope: quick` (default) — one-line snapshot for uptime, heap, rates, time sync, timezone, boot count, and version
 - `scope: runtime` — uptime, boot count, firmware version

--- a/docs-site/security.html
+++ b/docs-site/security.html
@@ -36,6 +36,7 @@
           <li><a href="local-dev.html">Chapter 6 · Local Dev &amp; Hacking</a></li>
           <li><a href="use-cases.html">Chapter 7 · Use Cases</a></li>
           <li><a href="changelog.html">Chapter 8 · Changelog</a></li>
+          <li><a href="local-admin.html">Chapter 9 · Local Admin Console</a></li>
         </ul>
       </aside>
 

--- a/docs-site/tools.html
+++ b/docs-site/tools.html
@@ -36,6 +36,7 @@
           <li><a href="local-dev.html">Chapter 6 · Local Dev &amp; Hacking</a></li>
           <li><a href="use-cases.html">Chapter 7 · Use Cases</a></li>
           <li><a href="changelog.html">Chapter 8 · Changelog</a></li>
+          <li><a href="local-admin.html">Chapter 9 · Local Admin Console</a></li>
         </ul>
       </aside>
 
@@ -87,7 +88,7 @@
         </section>
 
         <section class="section">
-          <h2>Telegram Control Commands</h2>
+          <h2>Chat Commands</h2>
           <table>
             <thead>
               <tr><th>Command</th><th>Behavior</th></tr>
@@ -96,11 +97,31 @@
               <tr><td><code>/start</code></td><td>Shows local command help without calling the LLM.</td></tr>
               <tr><td><code>/help</code></td><td>Alias of <code>/start</code>; returns local command help without calling the LLM.</td></tr>
               <tr><td><code>/settings</code></td><td>Shows local bot status (including paused/active intake state).</td></tr>
-              <tr><td><code>/diag [scope] [verbose]</code></td><td>Runs local diagnostics without an LLM call (available even when intake is paused).</td></tr>
               <tr><td><code>/stop</code></td><td>Pauses inbound message processing (used to stop spam loops).</td></tr>
               <tr><td><code>/resume</code></td><td>Re-enables inbound message processing after <code>/stop</code>.</td></tr>
             </tbody>
           </table>
+          <p class="inline-note">These commands work in Telegram and on the USB console. Hardware/admin commands live on the USB console only.</p>
+        </section>
+
+        <section class="section">
+          <h2>USB Local Admin Commands</h2>
+          <table>
+            <thead>
+              <tr><th>Command</th><th>Behavior</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>/gpio [all|pin|pin high|pin low]</code></td><td>Reads or drives tool-allowed GPIO pins locally without an LLM call.</td></tr>
+              <tr><td><code>/diag [scope] [verbose]</code></td><td>Runs local diagnostics over USB, including in safe mode or while intake is paused.</td></tr>
+              <tr><td><code>/wifi status</code></td><td>Shows provisioned SSID, driver/link state, IP, RSSI (when connected), and last disconnect reason.</td></tr>
+              <tr><td><code>/wifi scan</code></td><td>Runs a local Wi-Fi scan and lists visible APs with RSSI, auth mode, and channel.</td></tr>
+              <tr><td><code>/bootcount</code></td><td>Shows persisted boot-failure count and safe-mode threshold state.</td></tr>
+              <tr><td><code>/reboot</code></td><td>Reboots the board immediately after sending a local acknowledgement.</td></tr>
+              <tr><td><code>/factory-reset</code></td><td>Shows the destructive warning and required confirmation syntax.</td></tr>
+              <tr><td><code>/factory-reset confirm</code></td><td>Erases NVS (credentials, schedules, memory, boot state) and reboots.</td></tr>
+            </tbody>
+          </table>
+          <p class="inline-note">These commands are USB-local only. Telegram and web relay callers are rejected instead of falling through to the LLM path. See <a href="local-admin.html">Chapter 9</a>.</p>
         </section>
 
         <section class="section">

--- a/docs-site/use-cases.html
+++ b/docs-site/use-cases.html
@@ -36,6 +36,7 @@
           <li><a href="local-dev.html">Chapter 6 · Local Dev &amp; Hacking</a></li>
           <li><a href="use-cases.html">Chapter 7 · Use Cases</a></li>
           <li><a href="changelog.html">Chapter 8 · Changelog</a></li>
+          <li><a href="local-admin.html">Chapter 9 · Local Admin Console</a></li>
         </ul>
       </aside>
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,6 +5,7 @@ idf_component_register(
         "agent_commands.c"
         "agent_prompt.c"
         "channel.c"
+        "local_admin.c"
         "llm.c"
         "llm_auth.c"
         "http_gate.c"

--- a/main/agent.c
+++ b/main/agent.c
@@ -2,6 +2,7 @@
 #include "agent_commands.h"
 #include "agent_prompt.h"
 #include "config.h"
+#include "local_admin.h"
 #include "llm.h"
 #include "tools.h"
 #include "user_tools.h"
@@ -257,6 +258,89 @@ static void handle_diag_command(const char *user_message, int64_t chat_id, reque
     metrics_log_request(metrics, "diag_handled");
 }
 
+static void handle_gpio_command(const char *user_message, int64_t chat_id, request_metrics_t *metrics)
+{
+    char error[120] = {0};
+    cJSON *tool_input = cJSON_CreateObject();
+    const char *tool_name = NULL;
+    bool ok;
+    int64_t started_us;
+
+    if (!tool_input) {
+        send_response("Error: GPIO read unavailable (allocation failed)", chat_id);
+        metrics_log_request(metrics, "gpio_no_mem");
+        return;
+    }
+
+    if (!agent_parse_gpio_command_args(user_message, &tool_name, tool_input, error, sizeof(error))) {
+        send_response(error, chat_id);
+        cJSON_Delete(tool_input);
+        metrics_log_request(metrics, "gpio_invalid_args");
+        return;
+    }
+
+    s_tool_result_buf[0] = '\0';
+    started_us = esp_timer_get_time();
+    ok = tools_execute(tool_name, tool_input, s_tool_result_buf, sizeof(s_tool_result_buf));
+    metrics->tool_us_total += elapsed_us_since(started_us);
+    metrics->tool_calls++;
+    cJSON_Delete(tool_input);
+
+    if (!ok) {
+        if (s_tool_result_buf[0] == '\0') {
+            snprintf(s_tool_result_buf, sizeof(s_tool_result_buf), "Error: GPIO read failed");
+        }
+        send_response(s_tool_result_buf, chat_id);
+        metrics_log_request(metrics, "gpio_failed");
+        return;
+    }
+
+    send_response(s_tool_result_buf, chat_id);
+    metrics_log_request(metrics, "gpio_handled");
+}
+
+static bool is_local_admin_command(const char *user_message)
+{
+    return agent_is_command(user_message, "gpio") ||
+           agent_is_command(user_message, "diag") ||
+           local_admin_is_command(user_message);
+}
+
+static void handle_local_admin_command(const char *user_message,
+                                       message_source_t source,
+                                       int64_t chat_id,
+                                       request_metrics_t *metrics)
+{
+    char response[CHANNEL_TX_BUF_SIZE];
+    local_admin_action_t action = LOCAL_ADMIN_ACTION_NONE;
+
+    if (source != MSG_SOURCE_CHANNEL) {
+        send_response("Error: local admin commands are only available on the USB serial console.", chat_id);
+        metrics_log_request(metrics, "local_admin_remote_denied");
+        return;
+    }
+
+    if (agent_is_command(user_message, "diag")) {
+        handle_diag_command(user_message, chat_id, metrics);
+        return;
+    }
+
+    if (agent_is_command(user_message, "gpio")) {
+        handle_gpio_command(user_message, chat_id, metrics);
+        return;
+    }
+
+    if (!local_admin_handle_command(user_message, response, sizeof(response), &action)) {
+        send_response(response, chat_id);
+        metrics_log_request(metrics, "local_admin_invalid");
+        return;
+    }
+
+    send_response(response, chat_id);
+    metrics_log_request(metrics, "local_admin_handled");
+    local_admin_perform_action(action);
+}
+
 static void handle_start_command(int64_t chat_id)
 {
     static const char *START_HELP_TEXT =
@@ -271,12 +355,19 @@ static void handle_start_command(int64_t chat_id)
         "- turn the arcade on in 10 minutes\n"
         "- switch to witty persona\n"
         "\n"
-        "Telegram control commands:\n"
+        "Chat commands:\n"
         "- /help (show this message)\n"
         "- /settings (show status)\n"
-        "- /diag [scope] [verbose] (local diagnostics)\n"
         "- /stop (pause intake)\n"
-        "- /resume (resume)";
+        "- /resume (resume)\n"
+        "\n"
+        "USB local admin commands:\n"
+        "- /gpio [all|pin|pin high|pin low]\n"
+        "- /diag [scope] [verbose]\n"
+        "- /reboot\n"
+        "- /wifi [status|scan]\n"
+        "- /bootcount\n"
+        "- /factory-reset confirm";
     send_response(START_HELP_TEXT, chat_id);
 }
 
@@ -287,7 +378,9 @@ static void handle_settings_command(int64_t chat_id)
              "zclaw settings:\n"
              "- Message intake: %s\n"
              "- Persona: %s\n"
-             "- Telegram commands: /start, /help, /settings, /diag, /stop, /resume\n"
+             "- Chat commands: /start, /help, /settings, /stop, /resume\n"
+             "- USB local admin: /gpio, /diag, /reboot, /wifi, /bootcount, /factory-reset\n"
+             "- /gpio supports reads and writes (e.g. /gpio 9 low)\n"
              "- Persona changes: ask in normal chat (handled via tool calls)\n"
              "- Device settings are global (e.g., timezone <name>)",
              s_messages_paused ? "paused" : "active",
@@ -304,7 +397,7 @@ static int64_t response_chat_id_for_source(message_source_t source, int64_t chat
 }
 
 // Process a single user message
-static void process_message(const char *user_message, int64_t reply_chat_id)
+static void process_message(const char *user_message, message_source_t source, int64_t reply_chat_id)
 {
     ESP_LOGI(TAG, "Processing: %s", user_message);
     int history_turn_start = s_history_len;
@@ -338,8 +431,8 @@ static void process_message(const char *user_message, int64_t reply_chat_id)
         return;
     }
 
-    if (agent_is_command(user_message, "diag")) {
-        handle_diag_command(user_message, reply_chat_id, &metrics);
+    if (is_local_admin_command(user_message)) {
+        handle_local_admin_command(user_message, source, reply_chat_id, &metrics);
         return;
     }
 
@@ -649,6 +742,7 @@ void agent_test_reset(void)
     memset(s_last_non_command_text, 0, sizeof(s_last_non_command_text));
     s_messages_paused = false;
     memset(s_test_persona_value, 0, sizeof(s_test_persona_value));
+    local_admin_test_reset();
     load_persona_from_store();
 }
 
@@ -661,12 +755,12 @@ void agent_test_set_queues(QueueHandle_t channel_output_queue,
 
 void agent_test_process_message(const char *user_message)
 {
-    process_message(user_message, 0);
+    process_message(user_message, MSG_SOURCE_CHANNEL, 0);
 }
 
 void agent_test_process_message_for_chat(const char *user_message, int64_t reply_chat_id)
 {
-    process_message(user_message, reply_chat_id);
+    process_message(user_message, MSG_SOURCE_TELEGRAM, reply_chat_id);
 }
 #endif
 
@@ -680,7 +774,7 @@ static void agent_task(void *arg)
 
     while (1) {
         if (xQueueReceive(s_input_queue, &msg, portMAX_DELAY) == pdTRUE) {
-            process_message(msg.text, response_chat_id_for_source(msg.source, msg.chat_id));
+            process_message(msg.text, msg.source, response_chat_id_for_source(msg.source, msg.chat_id));
         }
     }
 }

--- a/main/agent_commands.c
+++ b/main/agent_commands.c
@@ -1,6 +1,7 @@
 #include "agent_commands.h"
 
 #include <ctype.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -48,7 +49,7 @@ bool agent_is_command(const char *message, const char *name)
     return true;
 }
 
-static const char *command_payload(const char *message, const char *name)
+const char *agent_command_payload(const char *message, const char *name)
 {
     const char *cursor;
     size_t name_len;
@@ -93,12 +94,109 @@ static bool is_diag_scope_token(const char *token)
            strcmp(token, "all") == 0;
 }
 
+static bool parse_gpio_state_token(const char *token, int *state_out)
+{
+    if (!token || !state_out) {
+        return false;
+    }
+
+    if (strcmp(token, "1") == 0 ||
+        strcmp(token, "high") == 0 ||
+        strcmp(token, "on") == 0) {
+        *state_out = 1;
+        return true;
+    }
+
+    if (strcmp(token, "0") == 0 ||
+        strcmp(token, "low") == 0 ||
+        strcmp(token, "off") == 0) {
+        *state_out = 0;
+        return true;
+    }
+
+    return false;
+}
+
+bool agent_parse_gpio_command_args(const char *message,
+                                   const char **tool_name_out,
+                                   cJSON *tool_input,
+                                   char *error,
+                                   size_t error_len)
+{
+    const char *payload = agent_command_payload(message, "gpio");
+    char payload_buf[64];
+    char *cursor;
+    char *state_token;
+    char *endptr = NULL;
+    long pin;
+    int state;
+
+    if (!tool_name_out || !tool_input) {
+        return false;
+    }
+
+    *tool_name_out = "gpio_read_all";
+
+    if (!payload || payload[0] == '\0') {
+        return true;
+    }
+
+    if (strlen(payload) >= sizeof(payload_buf)) {
+        snprintf(error, error_len, "Error: /gpio arguments too long");
+        return false;
+    }
+
+    snprintf(payload_buf, sizeof(payload_buf), "%s", payload);
+    cursor = strtok(payload_buf, " \t\r\n");
+    if (!cursor) {
+        return true;
+    }
+
+    if (strcmp(cursor, "all") == 0) {
+        if (strtok(NULL, " \t\r\n") != NULL) {
+            snprintf(error, error_len, "Error: /gpio all does not take extra arguments");
+            return false;
+        }
+        return true;
+    }
+
+    pin = strtol(cursor, &endptr, 10);
+    if (!endptr || *endptr != '\0') {
+        snprintf(error, error_len, "Error: unknown /gpio argument '%s' (use 'all' or a pin number)",
+                 cursor);
+        return false;
+    }
+    state_token = strtok(NULL, " \t\r\n");
+    if (!state_token) {
+        *tool_name_out = "gpio_read";
+        cJSON_AddNumberToObject(tool_input, "pin", pin);
+        return true;
+    }
+
+    if (!parse_gpio_state_token(state_token, &state)) {
+        snprintf(error, error_len,
+                 "Error: unknown GPIO state '%s' (use high/low/on/off/1/0)",
+                 state_token);
+        return false;
+    }
+
+    if (strtok(NULL, " \t\r\n") != NULL) {
+        snprintf(error, error_len, "Error: /gpio takes at most a pin and optional state");
+        return false;
+    }
+
+    *tool_name_out = "gpio_write";
+    cJSON_AddNumberToObject(tool_input, "pin", pin);
+    cJSON_AddNumberToObject(tool_input, "state", state);
+    return true;
+}
+
 bool agent_parse_diag_command_args(const char *message,
                                    cJSON *tool_input,
                                    char *error,
                                    size_t error_len)
 {
-    const char *payload = command_payload(message, "diag");
+    const char *payload = agent_command_payload(message, "diag");
     char payload_buf[128];
     char *cursor;
     bool verbose = false;

--- a/main/agent_commands.h
+++ b/main/agent_commands.h
@@ -9,6 +9,12 @@
 bool agent_is_command(const char *message, const char *name);
 bool agent_is_slash_command(const char *message);
 bool agent_is_cron_trigger_message(const char *message);
+const char *agent_command_payload(const char *message, const char *name);
+bool agent_parse_gpio_command_args(const char *message,
+                                   const char **tool_name_out,
+                                   cJSON *tool_input,
+                                   char *error,
+                                   size_t error_len);
 bool agent_parse_diag_command_args(const char *message,
                                    cJSON *tool_input,
                                    char *error,

--- a/main/local_admin.c
+++ b/main/local_admin.c
@@ -1,0 +1,682 @@
+#include "local_admin.h"
+
+#include "agent_commands.h"
+#include "boot_guard.h"
+#include "channel.h"
+#include "config.h"
+#include "memory.h"
+#include "nvs_keys.h"
+#include "wifi_credentials.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#ifndef TEST_BUILD
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+
+static const char *TAG = "local_admin";
+#else
+#include "mock_esp.h"
+#endif
+
+static bool s_safe_mode = false;
+static bool s_device_configured = false;
+
+#ifndef TEST_BUILD
+static EventGroupHandle_t s_wifi_event_group = NULL;
+static bool s_wifi_stack_ready = false;
+static bool s_wifi_netif_ready = false;
+static bool s_wifi_handlers_registered = false;
+static bool s_wifi_started = false;
+static bool s_wifi_connected = false;
+static bool s_wifi_connect_in_progress = false;
+static int s_wifi_retry_num = 0;
+static uint8_t s_last_disconnect_reason = 0;
+static char s_target_ssid[64] = {0};
+static char s_current_ip[16] = {0};
+
+#define LOCAL_ADMIN_WIFI_CONNECTED_BIT BIT0
+#define LOCAL_ADMIN_WIFI_FAIL_BIT      BIT1
+#define LOCAL_ADMIN_WIFI_SCAN_LIMIT    6
+
+#ifndef WIFI_REASON_BEACON_TIMEOUT
+#define WIFI_REASON_BEACON_TIMEOUT 200
+#endif
+#ifndef WIFI_REASON_NO_AP_FOUND
+#define WIFI_REASON_NO_AP_FOUND 201
+#endif
+#ifndef WIFI_REASON_AUTH_FAIL
+#define WIFI_REASON_AUTH_FAIL 202
+#endif
+#ifndef WIFI_REASON_ASSOC_FAIL
+#define WIFI_REASON_ASSOC_FAIL 203
+#endif
+#ifndef WIFI_REASON_HANDSHAKE_TIMEOUT
+#define WIFI_REASON_HANDSHAKE_TIMEOUT 204
+#endif
+
+static const char *wifi_disconnect_reason_name(uint8_t reason)
+{
+    switch (reason) {
+        case WIFI_REASON_AUTH_EXPIRE: return "AUTH_EXPIRE";
+        case WIFI_REASON_AUTH_LEAVE: return "AUTH_LEAVE";
+        case WIFI_REASON_ASSOC_EXPIRE: return "ASSOC_EXPIRE";
+        case WIFI_REASON_ASSOC_TOOMANY: return "ASSOC_TOOMANY";
+        case WIFI_REASON_NOT_AUTHED: return "NOT_AUTHED";
+        case WIFI_REASON_NOT_ASSOCED: return "NOT_ASSOCED";
+        case WIFI_REASON_ASSOC_LEAVE: return "ASSOC_LEAVE";
+        case WIFI_REASON_ASSOC_NOT_AUTHED: return "ASSOC_NOT_AUTHED";
+        case WIFI_REASON_MIC_FAILURE: return "MIC_FAILURE";
+        case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT: return "4WAY_HANDSHAKE_TIMEOUT";
+        case WIFI_REASON_GROUP_KEY_UPDATE_TIMEOUT: return "GROUP_KEY_UPDATE_TIMEOUT";
+        case WIFI_REASON_802_1X_AUTH_FAILED: return "802_1X_AUTH_FAILED";
+        case WIFI_REASON_BEACON_TIMEOUT: return "BEACON_TIMEOUT";
+        case WIFI_REASON_NO_AP_FOUND: return "NO_AP_FOUND";
+        case WIFI_REASON_AUTH_FAIL: return "AUTH_FAIL";
+        case WIFI_REASON_ASSOC_FAIL: return "ASSOC_FAIL";
+        case WIFI_REASON_HANDSHAKE_TIMEOUT: return "HANDSHAKE_TIMEOUT";
+        default: return "UNKNOWN";
+    }
+}
+
+static int wifi_channel_to_mhz(uint8_t channel)
+{
+    if (channel == 14) {
+        return 2484;
+    }
+    if (channel >= 1 && channel <= 13) {
+        return 2407 + (5 * channel);
+    }
+    if (channel >= 32 && channel <= 196) {
+        return 5000 + (5 * channel);
+    }
+    return 0;
+}
+
+static const char *wifi_authmode_name(wifi_auth_mode_t mode)
+{
+    switch (mode) {
+        case WIFI_AUTH_OPEN: return "OPEN";
+        case WIFI_AUTH_WEP: return "WEP";
+        case WIFI_AUTH_WPA_PSK: return "WPA_PSK";
+        case WIFI_AUTH_WPA2_PSK: return "WPA2_PSK";
+        case WIFI_AUTH_WPA_WPA2_PSK: return "WPA_WPA2_PSK";
+        case WIFI_AUTH_WPA2_ENTERPRISE: return "WPA2_ENTERPRISE";
+        case WIFI_AUTH_WPA3_PSK: return "WPA3_PSK";
+        case WIFI_AUTH_WPA2_WPA3_PSK: return "WPA2_WPA3_PSK";
+        case WIFI_AUTH_WAPI_PSK: return "WAPI_PSK";
+        default: return "UNKNOWN";
+    }
+}
+
+static void local_admin_wifi_event_handler(void *arg,
+                                           esp_event_base_t event_base,
+                                           int32_t event_id,
+                                           void *event_data)
+{
+    (void)arg;
+
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        s_wifi_started = true;
+        ESP_LOGI(TAG, "WiFi STA started");
+        return;
+    }
+
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        wifi_event_sta_disconnected_t *event = (wifi_event_sta_disconnected_t *)event_data;
+        s_wifi_connected = false;
+        s_current_ip[0] = '\0';
+        s_last_disconnect_reason = event ? event->reason : 0;
+        ESP_LOGW(TAG, "WiFi disconnected: reason=%u (%s)",
+                 s_last_disconnect_reason,
+                 wifi_disconnect_reason_name(s_last_disconnect_reason));
+
+        if (s_wifi_connect_in_progress && s_wifi_retry_num < WIFI_MAX_RETRY) {
+            esp_wifi_connect();
+            s_wifi_retry_num++;
+            ESP_LOGI(TAG, "WiFi retry %d/%d", s_wifi_retry_num, WIFI_MAX_RETRY);
+            return;
+        }
+
+        if (s_wifi_connect_in_progress && s_wifi_event_group) {
+            xEventGroupSetBits(s_wifi_event_group, LOCAL_ADMIN_WIFI_FAIL_BIT);
+        }
+        return;
+    }
+
+    if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
+        s_wifi_connected = true;
+        s_wifi_connect_in_progress = false;
+        s_wifi_retry_num = 0;
+        snprintf(s_current_ip, sizeof(s_current_ip), IPSTR, IP2STR(&event->ip_info.ip));
+        ESP_LOGI(TAG, "Connected: %s", s_current_ip);
+        if (s_wifi_event_group) {
+            xEventGroupSetBits(s_wifi_event_group, LOCAL_ADMIN_WIFI_CONNECTED_BIT);
+        }
+    }
+}
+
+static bool load_wifi_credentials(char *ssid,
+                                  size_t ssid_len,
+                                  char *pass,
+                                  size_t pass_len,
+                                  char *error,
+                                  size_t error_len)
+{
+    if (!memory_get(NVS_KEY_WIFI_SSID, ssid, ssid_len) || ssid[0] == '\0') {
+#if defined(CONFIG_ZCLAW_WIFI_SSID)
+        if (CONFIG_ZCLAW_WIFI_SSID[0] == '\0') {
+            if (error && error_len > 0) {
+                snprintf(error, error_len, "WiFi is not provisioned");
+            }
+            return false;
+        }
+        strncpy(ssid, CONFIG_ZCLAW_WIFI_SSID, ssid_len - 1);
+        ssid[ssid_len - 1] = '\0';
+#else
+        if (error && error_len > 0) {
+            snprintf(error, error_len, "WiFi is not provisioned");
+        }
+        return false;
+#endif
+    }
+
+    if (!memory_get(NVS_KEY_WIFI_PASS, pass, pass_len)) {
+#if defined(CONFIG_ZCLAW_WIFI_PASSWORD)
+        strncpy(pass, CONFIG_ZCLAW_WIFI_PASSWORD, pass_len - 1);
+        pass[pass_len - 1] = '\0';
+#else
+        pass[0] = '\0';
+#endif
+    }
+
+    if (!wifi_credentials_validate(ssid, pass, error, error_len)) {
+        return false;
+    }
+
+    return true;
+}
+
+static esp_err_t ensure_wifi_stack_ready(void)
+{
+    esp_err_t err;
+
+    if (s_wifi_stack_ready) {
+        return ESP_OK;
+    }
+
+    err = esp_netif_init();
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        return err;
+    }
+
+    err = esp_event_loop_create_default();
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        return err;
+    }
+
+    if (!s_wifi_netif_ready) {
+        esp_netif_create_default_wifi_sta();
+        s_wifi_netif_ready = true;
+    }
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    err = esp_wifi_init(&cfg);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        return err;
+    }
+
+    if (!s_wifi_handlers_registered) {
+        err = esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                         &local_admin_wifi_event_handler, NULL);
+        if (err != ESP_OK) {
+            return err;
+        }
+        err = esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                         &local_admin_wifi_event_handler, NULL);
+        if (err != ESP_OK) {
+            return err;
+        }
+        s_wifi_handlers_registered = true;
+    }
+
+    if (!s_wifi_event_group) {
+        s_wifi_event_group = xEventGroupCreate();
+        if (!s_wifi_event_group) {
+            return ESP_ERR_NO_MEM;
+        }
+    }
+
+    s_wifi_stack_ready = true;
+    return ESP_OK;
+}
+
+static esp_err_t ensure_wifi_started(void)
+{
+    esp_err_t err = ensure_wifi_stack_ready();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    if (s_wifi_started) {
+        return ESP_OK;
+    }
+
+    err = esp_wifi_set_mode(WIFI_MODE_STA);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = esp_wifi_start();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = esp_wifi_set_ps(WIFI_PS_NONE);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    s_wifi_started = true;
+    return ESP_OK;
+}
+
+static bool format_wifi_status(char *result, size_t result_len)
+{
+    char stored_ssid[64] = {0};
+    char pass[64] = {0};
+    char wifi_error[96] = {0};
+    wifi_ap_record_t ap_info = {0};
+    bool have_credentials = load_wifi_credentials(stored_ssid, sizeof(stored_ssid),
+                                                  pass, sizeof(pass),
+                                                  wifi_error, sizeof(wifi_error));
+    const char *ssid_text = s_target_ssid[0] != '\0'
+        ? s_target_ssid
+        : (have_credentials ? stored_ssid : "(none)");
+    esp_err_t ap_info_err = ESP_FAIL;
+
+    if (s_wifi_connected) {
+        ap_info_err = esp_wifi_sta_get_ap_info(&ap_info);
+    }
+
+    if (s_wifi_connected && ap_info_err == ESP_OK) {
+        snprintf(result, result_len,
+                 "WiFi status: provisioned=%s safe_mode=%s driver=%s link=%s ssid=%s ip=%s rssi=%d last_reason=%s",
+                 have_credentials ? "yes" : "no",
+                 s_safe_mode ? "yes" : "no",
+                 s_wifi_started ? "started" : "down",
+                 s_wifi_connected ? "connected" : "idle",
+                 ssid_text,
+                 s_current_ip[0] != '\0' ? s_current_ip : "(none)",
+                 ap_info.rssi,
+                 s_last_disconnect_reason ? wifi_disconnect_reason_name(s_last_disconnect_reason) : "none");
+        return true;
+    }
+
+    snprintf(result, result_len,
+             "WiFi status: provisioned=%s safe_mode=%s driver=%s link=%s ssid=%s ip=%s rssi=%s last_reason=%s",
+             have_credentials ? "yes" : "no",
+             s_safe_mode ? "yes" : "no",
+             s_wifi_started ? "started" : "down",
+             s_wifi_connected ? "connected" : "idle",
+             ssid_text,
+             s_current_ip[0] != '\0' ? s_current_ip : "(none)",
+             "(n/a)",
+             s_last_disconnect_reason ? wifi_disconnect_reason_name(s_last_disconnect_reason) : "none");
+
+    return true;
+}
+
+static bool format_wifi_scan(char *result, size_t result_len)
+{
+    esp_err_t err;
+    wifi_scan_config_t scan_cfg = {0};
+    wifi_ap_record_t records[LOCAL_ADMIN_WIFI_SCAN_LIMIT];
+    uint16_t ap_total = 0;
+    uint16_t record_count = LOCAL_ADMIN_WIFI_SCAN_LIMIT;
+    char *cursor = result;
+    size_t remaining = result_len;
+    int written;
+    int i;
+
+    err = ensure_wifi_started();
+    if (err != ESP_OK) {
+        snprintf(result, result_len, "Error: failed to start WiFi scan subsystem (%s)", esp_err_to_name(err));
+        return false;
+    }
+
+    scan_cfg.show_hidden = false;
+    err = esp_wifi_scan_start(&scan_cfg, true);
+    if (err != ESP_OK) {
+        snprintf(result, result_len, "Error: WiFi scan failed to start (%s)", esp_err_to_name(err));
+        return false;
+    }
+
+    err = esp_wifi_scan_get_ap_num(&ap_total);
+    if (err != ESP_OK) {
+        snprintf(result, result_len, "Error: WiFi scan count unavailable (%s)", esp_err_to_name(err));
+        return false;
+    }
+
+    if (ap_total == 0) {
+        snprintf(result, result_len, "WiFi scan: 0 APs visible");
+        return true;
+    }
+
+    if (record_count > ap_total) {
+        record_count = ap_total;
+    }
+    err = esp_wifi_scan_get_ap_records(&record_count, records);
+    if (err != ESP_OK) {
+        snprintf(result, result_len, "Error: WiFi scan results unavailable (%s)", esp_err_to_name(err));
+        return false;
+    }
+
+    written = snprintf(cursor, remaining, "WiFi scan: %u APs visible (top %u)", ap_total, record_count);
+    if (written < 0 || (size_t)written >= remaining) {
+        snprintf(result, result_len, "Error: WiFi scan output overflow");
+        return false;
+    }
+    cursor += (size_t)written;
+    remaining -= (size_t)written;
+
+    for (i = 0; i < record_count; i++) {
+        int mhz = wifi_channel_to_mhz(records[i].primary);
+        written = snprintf(cursor, remaining,
+                           "\n- %s rssi=%d auth=%s ch=%u%s",
+                           records[i].ssid[0] ? (const char *)records[i].ssid : "<hidden>",
+                           records[i].rssi,
+                           wifi_authmode_name(records[i].authmode),
+                           records[i].primary,
+                           mhz > 0 ? "" : "");
+        if (written < 0 || (size_t)written >= remaining) {
+            snprintf(result, result_len, "Error: WiFi scan output overflow");
+            return false;
+        }
+        cursor += (size_t)written;
+        remaining -= (size_t)written;
+
+        if (mhz > 0) {
+            written = snprintf(cursor, remaining, " (%dMHz)", mhz);
+            if (written < 0 || (size_t)written >= remaining) {
+                snprintf(result, result_len, "Error: WiFi scan output overflow");
+                return false;
+            }
+            cursor += (size_t)written;
+            remaining -= (size_t)written;
+        }
+    }
+
+    return true;
+}
+#else
+static char s_test_wifi_status[256] = "WiFi status: mock";
+static char s_test_wifi_scan[256] = "WiFi scan: mock";
+static local_admin_action_t s_test_last_action = LOCAL_ADMIN_ACTION_NONE;
+
+static bool format_wifi_status(char *result, size_t result_len)
+{
+    snprintf(result, result_len, "%s", s_test_wifi_status);
+    return true;
+}
+
+static bool format_wifi_scan(char *result, size_t result_len)
+{
+    snprintf(result, result_len, "%s", s_test_wifi_scan);
+    return true;
+}
+#endif
+
+void local_admin_set_safe_mode(bool safe_mode)
+{
+    s_safe_mode = safe_mode;
+}
+
+void local_admin_set_device_configured(bool device_configured)
+{
+    s_device_configured = device_configured;
+}
+
+bool local_admin_is_command(const char *message)
+{
+    return agent_is_command(message, "reboot") ||
+           agent_is_command(message, "wifi") ||
+           agent_is_command(message, "bootcount") ||
+           agent_is_command(message, "factory-reset");
+}
+
+bool local_admin_handle_command(const char *message,
+                                char *result,
+                                size_t result_len,
+                                local_admin_action_t *action_out)
+{
+    const char *payload = NULL;
+    char payload_buf[64];
+    char *token = NULL;
+    char *extra = NULL;
+
+    if (!message || !result || result_len == 0) {
+        return false;
+    }
+
+    if (action_out) {
+        *action_out = LOCAL_ADMIN_ACTION_NONE;
+    }
+
+    if (agent_is_command(message, "reboot")) {
+        payload = agent_command_payload(message, "reboot");
+        if (payload && payload[0] != '\0') {
+            snprintf(result, result_len, "Error: /reboot does not take arguments");
+            return false;
+        }
+        if (action_out) {
+            *action_out = LOCAL_ADMIN_ACTION_REBOOT;
+        }
+        snprintf(result, result_len, "Rebooting...");
+        return true;
+    }
+
+    if (agent_is_command(message, "bootcount")) {
+        int boot_count = boot_guard_get_persisted_count();
+        int remaining_before_safe = MAX_BOOT_FAILURES - boot_count;
+        if (remaining_before_safe < 0) {
+            remaining_before_safe = 0;
+        }
+
+        payload = agent_command_payload(message, "bootcount");
+        if (payload && payload[0] != '\0') {
+            snprintf(result, result_len, "Error: /bootcount does not take arguments");
+            return false;
+        }
+
+        snprintf(result, result_len,
+                 "Boot count: persisted=%d max_failures=%d remaining_before_safe=%d safe_mode=%s configured=%s",
+                 boot_count,
+                 MAX_BOOT_FAILURES,
+                 remaining_before_safe,
+                 s_safe_mode ? "yes" : "no",
+                 s_device_configured ? "yes" : "no");
+        return true;
+    }
+
+    if (agent_is_command(message, "factory-reset")) {
+        payload = agent_command_payload(message, "factory-reset");
+        if (!payload || payload[0] == '\0') {
+            snprintf(result, result_len,
+                     "Factory reset will erase WiFi credentials, tokens, schedules, memories, and boot state. Run /factory-reset confirm to continue.");
+            return true;
+        }
+
+        if (strlen(payload) >= sizeof(payload_buf)) {
+            snprintf(result, result_len, "Error: /factory-reset arguments too long");
+            return false;
+        }
+
+        snprintf(payload_buf, sizeof(payload_buf), "%s", payload);
+        token = strtok(payload_buf, " \t\r\n");
+        extra = strtok(NULL, " \t\r\n");
+        if (!token || strcmp(token, "confirm") != 0 || extra != NULL) {
+            snprintf(result, result_len, "Error: use /factory-reset confirm");
+            return false;
+        }
+
+        if (action_out) {
+            *action_out = LOCAL_ADMIN_ACTION_FACTORY_RESET_REBOOT;
+        }
+        snprintf(result, result_len, "Factory reset confirmed. Erasing NVS and rebooting...");
+        return true;
+    }
+
+    if (agent_is_command(message, "wifi")) {
+        payload = agent_command_payload(message, "wifi");
+        if (!payload || payload[0] == '\0' || strcmp(payload, "status") == 0) {
+            return format_wifi_status(result, result_len);
+        }
+
+        if (strlen(payload) >= sizeof(payload_buf)) {
+            snprintf(result, result_len, "Error: /wifi arguments too long");
+            return false;
+        }
+
+        snprintf(payload_buf, sizeof(payload_buf), "%s", payload);
+        token = strtok(payload_buf, " \t\r\n");
+        extra = strtok(NULL, " \t\r\n");
+        if (!token) {
+            return format_wifi_status(result, result_len);
+        }
+        if (extra != NULL) {
+            snprintf(result, result_len, "Error: /wifi takes at most one argument");
+            return false;
+        }
+        if (strcmp(token, "status") == 0) {
+            return format_wifi_status(result, result_len);
+        }
+        if (strcmp(token, "scan") == 0) {
+            return format_wifi_scan(result, result_len);
+        }
+
+        snprintf(result, result_len, "Error: unknown /wifi argument '%s' (use status or scan)", token);
+        return false;
+    }
+
+    snprintf(result, result_len, "Error: unknown local admin command");
+    return false;
+}
+
+void local_admin_perform_action(local_admin_action_t action)
+{
+#ifdef TEST_BUILD
+    s_test_last_action = action;
+    if (action == LOCAL_ADMIN_ACTION_FACTORY_RESET_REBOOT) {
+        (void)memory_factory_reset();
+    }
+#else
+    if (action == LOCAL_ADMIN_ACTION_NONE) {
+        return;
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(250));
+
+    if (action == LOCAL_ADMIN_ACTION_FACTORY_RESET_REBOOT) {
+        esp_err_t err = memory_factory_reset();
+        if (err != ESP_OK) {
+            channel_write("\r\nFactory reset failed.\r\n\r\n");
+            return;
+        }
+    }
+
+    esp_restart();
+#endif
+}
+
+bool local_admin_wifi_connect_from_store(void)
+{
+#ifdef TEST_BUILD
+    return s_device_configured;
+#else
+    char ssid[64] = {0};
+    char pass[64] = {0};
+    char wifi_error[96] = {0};
+    esp_err_t err;
+    wifi_config_t wifi_config = {0};
+    EventBits_t bits;
+
+    if (!load_wifi_credentials(ssid, sizeof(ssid), pass, sizeof(pass), wifi_error, sizeof(wifi_error))) {
+        ESP_LOGE(TAG, "%s", wifi_error);
+        return false;
+    }
+
+    err = ensure_wifi_started();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize WiFi: %s", esp_err_to_name(err));
+        return false;
+    }
+
+    strncpy(s_target_ssid, ssid, sizeof(s_target_ssid) - 1);
+    s_target_ssid[sizeof(s_target_ssid) - 1] = '\0';
+    s_current_ip[0] = '\0';
+    s_last_disconnect_reason = 0;
+    s_wifi_retry_num = 0;
+    s_wifi_connected = false;
+    s_wifi_connect_in_progress = true;
+    xEventGroupClearBits(s_wifi_event_group,
+                         LOCAL_ADMIN_WIFI_CONNECTED_BIT | LOCAL_ADMIN_WIFI_FAIL_BIT);
+
+    wifi_credentials_copy_to_sta_config(wifi_config.sta.ssid, wifi_config.sta.password, ssid, pass);
+    wifi_config.sta.threshold.authmode = pass[0] ? WIFI_AUTH_WPA_PSK : WIFI_AUTH_OPEN;
+
+    err = esp_wifi_set_config(WIFI_IF_STA, &wifi_config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to configure WiFi: %s", esp_err_to_name(err));
+        return false;
+    }
+
+    ESP_LOGI(TAG, "Connecting to %s...", ssid);
+    err = esp_wifi_connect();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to start WiFi connect: %s", esp_err_to_name(err));
+        return false;
+    }
+
+    bits = xEventGroupWaitBits(s_wifi_event_group,
+                               LOCAL_ADMIN_WIFI_CONNECTED_BIT | LOCAL_ADMIN_WIFI_FAIL_BIT,
+                               pdFALSE, pdFALSE, portMAX_DELAY);
+    return (bits & LOCAL_ADMIN_WIFI_CONNECTED_BIT) != 0;
+#endif
+}
+
+#ifdef TEST_BUILD
+void local_admin_test_reset(void)
+{
+    s_safe_mode = false;
+    s_device_configured = false;
+    snprintf(s_test_wifi_status, sizeof(s_test_wifi_status), "%s", "WiFi status: mock");
+    snprintf(s_test_wifi_scan, sizeof(s_test_wifi_scan), "%s", "WiFi scan: mock");
+    s_test_last_action = LOCAL_ADMIN_ACTION_NONE;
+}
+
+void local_admin_test_set_wifi_status(const char *status_text)
+{
+    snprintf(s_test_wifi_status, sizeof(s_test_wifi_status), "%s",
+             status_text ? status_text : "WiFi status: mock");
+}
+
+void local_admin_test_set_wifi_scan(const char *scan_text)
+{
+    snprintf(s_test_wifi_scan, sizeof(s_test_wifi_scan), "%s",
+             scan_text ? scan_text : "WiFi scan: mock");
+}
+
+local_admin_action_t local_admin_test_last_action(void)
+{
+    return s_test_last_action;
+}
+#endif

--- a/main/local_admin.h
+++ b/main/local_admin.h
@@ -1,0 +1,33 @@
+#ifndef LOCAL_ADMIN_H
+#define LOCAL_ADMIN_H
+
+#include "esp_err.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef enum {
+    LOCAL_ADMIN_ACTION_NONE = 0,
+    LOCAL_ADMIN_ACTION_REBOOT,
+    LOCAL_ADMIN_ACTION_FACTORY_RESET_REBOOT,
+} local_admin_action_t;
+
+void local_admin_set_safe_mode(bool safe_mode);
+void local_admin_set_device_configured(bool device_configured);
+
+bool local_admin_is_command(const char *message);
+bool local_admin_handle_command(const char *message,
+                                char *result,
+                                size_t result_len,
+                                local_admin_action_t *action_out);
+void local_admin_perform_action(local_admin_action_t action);
+
+bool local_admin_wifi_connect_from_store(void);
+
+#ifdef TEST_BUILD
+void local_admin_test_reset(void);
+void local_admin_test_set_wifi_status(const char *status_text);
+void local_admin_test_set_wifi_scan(const char *scan_text);
+local_admin_action_t local_admin_test_last_action(void);
+#endif
+
+#endif // LOCAL_ADMIN_H

--- a/main/main.c
+++ b/main/main.c
@@ -10,168 +10,21 @@
 #include "ota.h"
 #include "http_gate.h"
 #include "boot_guard.h"
+#include "local_admin.h"
 #include "nvs_keys.h"
 #include "messages.h"
-#include "wifi_credentials.h"
 #include "gpio_policy.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
-#include "freertos/event_groups.h"
-#include "esp_wifi.h"
-#include "esp_event.h"
 #include "esp_log.h"
 #include "esp_err.h"
 #include "esp_system.h"
-#include "nvs_flash.h"
 #include "driver/gpio.h"
-#include <string.h>
 
 static const char *TAG = "main";
-
-// WiFi event group
-static EventGroupHandle_t s_wifi_event_group;
-#define WIFI_CONNECTED_BIT BIT0
-#define WIFI_FAIL_BIT      BIT1
-
-static int s_retry_num = 0;
 static bool s_safe_mode = false;
-static uint8_t s_last_disconnect_reason = 0;
-
-#ifndef WIFI_REASON_BEACON_TIMEOUT
-#define WIFI_REASON_BEACON_TIMEOUT 200
-#endif
-#ifndef WIFI_REASON_NO_AP_FOUND
-#define WIFI_REASON_NO_AP_FOUND 201
-#endif
-#ifndef WIFI_REASON_AUTH_FAIL
-#define WIFI_REASON_AUTH_FAIL 202
-#endif
-#ifndef WIFI_REASON_ASSOC_FAIL
-#define WIFI_REASON_ASSOC_FAIL 203
-#endif
-#ifndef WIFI_REASON_HANDSHAKE_TIMEOUT
-#define WIFI_REASON_HANDSHAKE_TIMEOUT 204
-#endif
-
-static const char *wifi_disconnect_reason_name(uint8_t reason)
-{
-    switch (reason) {
-        case WIFI_REASON_AUTH_EXPIRE: return "AUTH_EXPIRE";
-        case WIFI_REASON_AUTH_LEAVE: return "AUTH_LEAVE";
-        case WIFI_REASON_ASSOC_EXPIRE: return "ASSOC_EXPIRE";
-        case WIFI_REASON_ASSOC_TOOMANY: return "ASSOC_TOOMANY";
-        case WIFI_REASON_NOT_AUTHED: return "NOT_AUTHED";
-        case WIFI_REASON_NOT_ASSOCED: return "NOT_ASSOCED";
-        case WIFI_REASON_ASSOC_LEAVE: return "ASSOC_LEAVE";
-        case WIFI_REASON_ASSOC_NOT_AUTHED: return "ASSOC_NOT_AUTHED";
-        case WIFI_REASON_MIC_FAILURE: return "MIC_FAILURE";
-        case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT: return "4WAY_HANDSHAKE_TIMEOUT";
-        case WIFI_REASON_GROUP_KEY_UPDATE_TIMEOUT: return "GROUP_KEY_UPDATE_TIMEOUT";
-        case WIFI_REASON_802_1X_AUTH_FAILED: return "802_1X_AUTH_FAILED";
-        case WIFI_REASON_BEACON_TIMEOUT: return "BEACON_TIMEOUT";
-        case WIFI_REASON_NO_AP_FOUND: return "NO_AP_FOUND";
-        case WIFI_REASON_AUTH_FAIL: return "AUTH_FAIL";
-        case WIFI_REASON_ASSOC_FAIL: return "ASSOC_FAIL";
-        case WIFI_REASON_HANDSHAKE_TIMEOUT: return "HANDSHAKE_TIMEOUT";
-        default: return "UNKNOWN";
-    }
-}
-
-static const char *wifi_disconnect_reason_hint(uint8_t reason)
-{
-    switch (reason) {
-        case WIFI_REASON_NO_AP_FOUND:
-            return "SSID not found. Confirm exact SSID and ensure 2.4GHz is enabled.";
-        case WIFI_REASON_AUTH_FAIL:
-        case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
-        case WIFI_REASON_HANDSHAKE_TIMEOUT:
-            return "Authentication failed. Re-run provisioning and double-check WiFi password.";
-        case WIFI_REASON_802_1X_AUTH_FAILED:
-            return "AP may require WPA2-Enterprise (802.1X), which is not supported by PSK provisioning.";
-        case WIFI_REASON_ASSOC_FAIL:
-            return "Association failed. Check router compatibility (WPA2/WPA3 mixed mode recommended).";
-        case WIFI_REASON_BEACON_TIMEOUT:
-            return "AP not stable/reachable. Move device closer or reduce interference.";
-        default:
-            return NULL;
-    }
-}
-
-static int wifi_channel_to_mhz(uint8_t channel)
-{
-    if (channel == 14) {
-        return 2484;
-    }
-    if (channel >= 1 && channel <= 13) {
-        return 2407 + (5 * channel);
-    }
-    if (channel >= 32 && channel <= 196) {
-        return 5000 + (5 * channel);
-    }
-    return 0;
-}
-
-static const char *wifi_authmode_name(wifi_auth_mode_t mode)
-{
-    switch (mode) {
-        case WIFI_AUTH_OPEN: return "OPEN";
-        case WIFI_AUTH_WEP: return "WEP";
-        case WIFI_AUTH_WPA_PSK: return "WPA_PSK";
-        case WIFI_AUTH_WPA2_PSK: return "WPA2_PSK";
-        case WIFI_AUTH_WPA_WPA2_PSK: return "WPA_WPA2_PSK";
-        case WIFI_AUTH_WPA2_ENTERPRISE: return "WPA2_ENTERPRISE";
-        case WIFI_AUTH_WPA3_PSK: return "WPA3_PSK";
-        case WIFI_AUTH_WPA2_WPA3_PSK: return "WPA2_WPA3_PSK";
-        case WIFI_AUTH_WAPI_PSK: return "WAPI_PSK";
-        default: return "UNKNOWN";
-    }
-}
-
-static void log_target_ap_scan(const char *ssid)
-{
-    wifi_scan_config_t scan_cfg = {0};
-    uint16_t ap_num = 0;
-    uint16_t record_count = 1;
-    wifi_ap_record_t ap = {0};
-
-    if (ssid == NULL || ssid[0] == '\0') {
-        return;
-    }
-
-    scan_cfg.ssid = (uint8_t *)ssid;
-    scan_cfg.show_hidden = true;
-
-    if (esp_wifi_scan_start(&scan_cfg, true) != ESP_OK) {
-        ESP_LOGW(TAG, "WiFi scan failed before connect");
-        return;
-    }
-
-    if (esp_wifi_scan_get_ap_num(&ap_num) != ESP_OK) {
-        ESP_LOGW(TAG, "WiFi scan result count unavailable");
-        return;
-    }
-
-    if (ap_num == 0) {
-        ESP_LOGW(TAG, "WiFi scan: '%s' not visible on 2.4GHz", ssid);
-        return;
-    }
-
-    if (esp_wifi_scan_get_ap_records(&record_count, &ap) != ESP_OK || record_count == 0) {
-        ESP_LOGW(TAG, "WiFi scan: no AP record available for '%s'", ssid);
-        return;
-    }
-
-    int mhz = wifi_channel_to_mhz(ap.primary);
-    if (mhz > 0) {
-        ESP_LOGI(TAG, "WiFi scan: ssid='%s' channel=%u freq=%dMHz auth=%s rssi=%d",
-                 ssid, ap.primary, mhz, wifi_authmode_name(ap.authmode), ap.rssi);
-    } else {
-        ESP_LOGI(TAG, "WiFi scan: ssid='%s' channel=%u auth=%s rssi=%d",
-                 ssid, ap.primary, wifi_authmode_name(ap.authmode), ap.rssi);
-    }
-}
 
 static void fail_fast_startup(const char *component, esp_err_t err)
 {
@@ -210,42 +63,6 @@ static void clear_boot_count(void *arg)
     vTaskDelete(NULL);
 }
 
-// WiFi event handler
-static void wifi_event_handler(void *arg, esp_event_base_t event_base,
-                                int32_t event_id, void *event_data)
-{
-    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
-        ESP_LOGI(TAG, "WiFi STA started");
-    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
-        wifi_event_sta_disconnected_t *event = (wifi_event_sta_disconnected_t *)event_data;
-        uint8_t reason = event ? event->reason : 0;
-        const char *reason_name = wifi_disconnect_reason_name(reason);
-        const char *hint = wifi_disconnect_reason_hint(reason);
-
-        s_last_disconnect_reason = reason;
-        ESP_LOGW(TAG, "WiFi disconnected: reason=%u (%s)", reason, reason_name);
-        if (hint) {
-            ESP_LOGW(TAG, "WiFi hint: %s", hint);
-        }
-
-        if (s_retry_num < WIFI_MAX_RETRY) {
-            esp_wifi_connect();
-            s_retry_num++;
-            ESP_LOGI(TAG, "WiFi retry %d/%d", s_retry_num, WIFI_MAX_RETRY);
-        } else {
-            xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
-            ESP_LOGE(TAG, "WiFi connection failed after %d retries (last reason=%u: %s)",
-                     WIFI_MAX_RETRY, s_last_disconnect_reason,
-                     wifi_disconnect_reason_name(s_last_disconnect_reason));
-        }
-    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
-        ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
-        ESP_LOGI(TAG, "Connected: " IPSTR, IP2STR(&event->ip_info.ip));
-        s_retry_num = 0;
-        xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
-    }
-}
-
 // Check factory reset button
 static bool check_factory_reset(void)
 {
@@ -270,8 +87,8 @@ static bool check_factory_reset(void)
 
         if (held_ms >= FACTORY_RESET_HOLD_MS) {
             ESP_LOGW(TAG, "Factory reset triggered!");
-            nvs_flash_erase();
-            ESP_LOGI(TAG, "NVS erased, restarting...");
+            ESP_ERROR_CHECK(memory_factory_reset());
+            ESP_LOGI(TAG, "Factory reset complete, restarting...");
             vTaskDelay(pdMS_TO_TICKS(1000));
             esp_restart();
             return true;
@@ -304,85 +121,6 @@ static void print_provisioning_help(void)
     ESP_LOGE(TAG, "  ./scripts/provision.sh --port <serial-port>");
     ESP_LOGE(TAG, "Then restart the board.");
     ESP_LOGE(TAG, "");
-}
-
-// Connect to WiFi using stored credentials
-static bool wifi_connect_sta(void)
-{
-    char ssid[64] = {0};
-    char pass[64] = {0};
-    char wifi_error[96] = {0};
-
-    if (!memory_get(NVS_KEY_WIFI_SSID, ssid, sizeof(ssid)) || ssid[0] == '\0') {
-#if defined(CONFIG_ZCLAW_WIFI_SSID)
-        if (CONFIG_ZCLAW_WIFI_SSID[0] == '\0') {
-            return false;
-        }
-        strncpy(ssid, CONFIG_ZCLAW_WIFI_SSID, sizeof(ssid) - 1);
-        ssid[sizeof(ssid) - 1] = '\0';
-#else
-        return false;
-#endif
-    }
-
-    if (!memory_get(NVS_KEY_WIFI_PASS, pass, sizeof(pass))) {
-#if defined(CONFIG_ZCLAW_WIFI_PASSWORD)
-        strncpy(pass, CONFIG_ZCLAW_WIFI_PASSWORD, sizeof(pass) - 1);
-        pass[sizeof(pass) - 1] = '\0';
-#else
-        pass[0] = '\0';
-#endif
-    }
-
-    if (!wifi_credentials_validate(ssid, pass, wifi_error, sizeof(wifi_error))) {
-        ESP_LOGE(TAG, "Invalid WiFi credentials: %s", wifi_error);
-        return false;
-    }
-
-    ESP_LOGI(TAG, "Loaded WiFi credentials: ssid='%s', password_len=%u",
-             ssid, (unsigned)strlen(pass));
-
-    s_wifi_event_group = xEventGroupCreate();
-    if (!s_wifi_event_group) {
-        ESP_LOGE(TAG, "Failed to create WiFi event group");
-        return false;
-    }
-
-    ESP_ERROR_CHECK(esp_netif_init());
-    ESP_ERROR_CHECK(esp_event_loop_create_default());
-    esp_netif_create_default_wifi_sta();
-
-    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
-
-    esp_event_handler_instance_t instance_any_id;
-    esp_event_handler_instance_t instance_got_ip;
-    ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
-                                                         &wifi_event_handler, NULL, &instance_any_id));
-    ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
-                                                         &wifi_event_handler, NULL, &instance_got_ip));
-
-    wifi_config_t wifi_config = {0};
-    wifi_credentials_copy_to_sta_config(wifi_config.sta.ssid, wifi_config.sta.password, ssid, pass);
-    // Allow WPA/WPA2/WPA3 PSK networks; open networks stay open-only.
-    wifi_config.sta.threshold.authmode = pass[0] ? WIFI_AUTH_WPA_PSK : WIFI_AUTH_OPEN;
-
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
-    ESP_ERROR_CHECK(esp_wifi_start());
-    // Favor link stability for HTTPS-heavy workloads over power savings.
-    ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
-    ESP_LOGI(TAG, "WiFi power save disabled");
-
-    log_target_ap_scan(ssid);
-    ESP_LOGI(TAG, "Connecting to %s...", ssid);
-    ESP_ERROR_CHECK(esp_wifi_connect());
-
-    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
-                                            WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
-                                            pdFALSE, pdFALSE, portMAX_DELAY);
-
-    return (bits & WIFI_CONNECTED_BIT) != 0;
 }
 
 void app_main(void)
@@ -426,6 +164,8 @@ void app_main(void)
     }
 #endif
 
+    local_admin_set_safe_mode(s_safe_mode);
+
 #if CONFIG_ZCLAW_EMULATOR_MODE
     ESP_LOGW(TAG, "Emulator mode enabled: skipping WiFi/NTP/Telegram startup");
 #ifndef CONFIG_ZCLAW_STUB_LLM
@@ -461,8 +201,58 @@ void app_main(void)
     }
 #else
 
-    // 4. Check if configured or in safe mode
-    if (!device_is_configured() || s_safe_mode) {
+    bool device_configured = device_is_configured();
+    local_admin_set_device_configured(device_configured);
+
+    // 5. Initialize LLM client for local serial commands
+    ESP_ERROR_CHECK(llm_init());
+
+    // 6. Initialize rate limiter
+    ratelimit_init();
+
+    // 7. Initialize Telegram config state
+#if CONFIG_ZCLAW_STUB_TELEGRAM
+    ESP_LOGW(TAG, "Telegram stub mode enabled; skipping Telegram startup");
+#else
+    esp_err_t telegram_init_err = telegram_init();  // Missing token is non-fatal
+    if (telegram_init_err != ESP_OK && telegram_init_err != ESP_ERR_NOT_FOUND) {
+        fail_fast_startup("telegram_init", telegram_init_err);
+    }
+#endif
+
+    // 8. Register tools and local channel early so /gpio and /diag work before WiFi.
+    tools_init();
+    channel_init();
+
+    QueueHandle_t input_queue = xQueueCreate(INPUT_QUEUE_LENGTH, sizeof(channel_msg_t));
+    QueueHandle_t channel_output_queue = xQueueCreate(OUTPUT_QUEUE_LENGTH, sizeof(channel_output_msg_t));
+    QueueHandle_t telegram_output_queue = NULL;
+#if CONFIG_ZCLAW_STUB_TELEGRAM
+    bool telegram_enabled = false;
+#else
+    bool telegram_enabled = device_configured && !s_safe_mode && telegram_is_configured();
+#endif
+    if (telegram_enabled) {
+        telegram_output_queue = xQueueCreate(TELEGRAM_OUTPUT_QUEUE_LENGTH, sizeof(telegram_msg_t));
+    }
+
+    if (!input_queue || !channel_output_queue || (telegram_enabled && !telegram_output_queue)) {
+        ESP_LOGE(TAG, "Failed to create queues");
+        esp_restart();
+    }
+
+    esp_err_t startup_err = channel_start(input_queue, channel_output_queue);
+    if (startup_err != ESP_OK) {
+        fail_fast_startup("channel_start", startup_err);
+    }
+
+    startup_err = agent_start(input_queue, channel_output_queue, telegram_output_queue);
+    if (startup_err != ESP_OK) {
+        fail_fast_startup("agent_start", startup_err);
+    }
+
+    // 9. Check if configured or in safe mode
+    if (!device_configured || s_safe_mode) {
         if (s_safe_mode) {
             ESP_LOGE(TAG, "");
             ESP_LOGE(TAG, "========================================");
@@ -474,76 +264,34 @@ void app_main(void)
             ESP_LOGE(TAG, "  1) Hold BOOT for factory reset");
             ESP_LOGE(TAG, "  2) Reflash firmware and reprovision");
             ESP_LOGE(TAG, "");
+            channel_write("\r\nSAFE MODE - local serial commands remain available.\r\n"
+                          "Try /gpio, /diag, /reboot, /wifi, /bootcount, /factory-reset, /help, or /settings.\r\n\r\n");
         } else {
             print_provisioning_help();
+            channel_write("\r\nDevice is not provisioned.\r\n"
+                          "Local serial commands remain available: /gpio, /diag, /reboot, /wifi, /bootcount, /factory-reset, /help, /settings.\r\n\r\n");
         }
         while (1) {
             vTaskDelay(pdMS_TO_TICKS(5000));
         }
     }
 
-    // 5. Connect to WiFi
-    if (!wifi_connect_sta()) {
+    // 10. Connect to WiFi
+    if (!local_admin_wifi_connect_from_store()) {
         ESP_LOGE(TAG, "WiFi failed, restarting...");
         vTaskDelay(pdMS_TO_TICKS(3000));
         esp_restart();
     }
 
-    // 6. Start task to clear boot counter after stable period
+    // 11. Start task to clear boot counter after stable period
     if (xTaskCreate(clear_boot_count, "boot_ok", BOOT_OK_TASK_STACK_SIZE, NULL, 1, NULL) != pdPASS) {
         ESP_LOGE(TAG, "Failed to create boot confirmation task");
     }
 
-    // 7. Initialize cron (includes NTP sync)
+    // 12. Initialize cron (includes NTP sync)
     ESP_ERROR_CHECK(cron_init());
 
-    // 8. Initialize LLM client
-    ESP_ERROR_CHECK(llm_init());
-
-    // 9. Initialize rate limiter
-    ratelimit_init();
-
-    // 10. Initialize Telegram
-#if CONFIG_ZCLAW_STUB_TELEGRAM
-    ESP_LOGW(TAG, "Telegram stub mode enabled; skipping Telegram startup");
-#else
-    esp_err_t telegram_init_err = telegram_init();  // Missing token is non-fatal
-    if (telegram_init_err != ESP_OK && telegram_init_err != ESP_ERR_NOT_FOUND) {
-        fail_fast_startup("telegram_init", telegram_init_err);
-    }
-#endif
-
-    // 11. Register tools
-    tools_init();
-
-    // 12. Initialize USB serial channel
-    channel_init();
-
-    // 13. Create queues
-    QueueHandle_t input_queue = xQueueCreate(INPUT_QUEUE_LENGTH, sizeof(channel_msg_t));
-    QueueHandle_t channel_output_queue = xQueueCreate(OUTPUT_QUEUE_LENGTH, sizeof(channel_output_msg_t));
-    QueueHandle_t telegram_output_queue = NULL;
-#if CONFIG_ZCLAW_STUB_TELEGRAM
-    bool telegram_enabled = false;
-#else
-    bool telegram_enabled = telegram_is_configured();
-#endif
-    if (telegram_enabled) {
-        telegram_output_queue = xQueueCreate(TELEGRAM_OUTPUT_QUEUE_LENGTH, sizeof(telegram_msg_t));
-    }
-
-    if (!input_queue || !channel_output_queue || (telegram_enabled && !telegram_output_queue)) {
-        ESP_LOGE(TAG, "Failed to create queues");
-        esp_restart();
-    }
-
-    // 14. Start channel task (USB serial)
-    esp_err_t startup_err = channel_start(input_queue, channel_output_queue);
-    if (startup_err != ESP_OK) {
-        fail_fast_startup("channel_start", startup_err);
-    }
-
-    // 15. Start Telegram channel
+    // 13. Start Telegram channel
     if (telegram_enabled) {
         startup_err = telegram_start(input_queue, telegram_output_queue);
         if (startup_err != ESP_OK) {
@@ -551,26 +299,20 @@ void app_main(void)
         }
     }
 
-    // 16. Start agent task
-    startup_err = agent_start(input_queue, channel_output_queue, telegram_output_queue);
-    if (startup_err != ESP_OK) {
-        fail_fast_startup("agent_start", startup_err);
-    }
-
-    // 17. Start cron task
+    // 14. Start cron task
     startup_err = cron_start(input_queue);
     if (startup_err != ESP_OK) {
         fail_fast_startup("cron_start", startup_err);
     }
 
-    // 18. Print ready message
+    // 15. Print ready message
     ESP_LOGI(TAG, "");
     ESP_LOGI(TAG, "========================================");
     ESP_LOGI(TAG, "  Ready! Free heap: %lu bytes", esp_get_free_heap_size());
     ESP_LOGI(TAG, "========================================");
     ESP_LOGI(TAG, "");
 
-    // 19. Send startup notification on Telegram
+    // 16. Send startup notification on Telegram
     if (telegram_enabled && telegram_is_configured()) {
         telegram_send_startup();
     }

--- a/main/memory.c
+++ b/main/memory.c
@@ -161,3 +161,15 @@ esp_err_t memory_delete(const char *key)
     nvs_close(handle);
     return err;
 }
+
+esp_err_t memory_factory_reset(void)
+{
+    esp_err_t err = nvs_flash_erase();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Factory reset erase failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    ESP_LOGW(TAG, "Factory reset: erased NVS storage");
+    return ESP_OK;
+}

--- a/main/memory.h
+++ b/main/memory.h
@@ -16,4 +16,7 @@ bool memory_get(const char *key, char *value, size_t max_len);
 // Delete a key
 esp_err_t memory_delete(const char *key);
 
+// Erase all persisted state in the configured NVS storage.
+esp_err_t memory_factory_reset(void);
+
 #endif // MEMORY_H

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -93,6 +93,7 @@ run_host_tests() {
         ../../main/agent_commands.c \
         ../../main/agent_prompt.c \
         ../../main/agent.c \
+        ../../main/local_admin.c \
         ../../main/gpio_policy.c \
         ../../main/tools_gpio.c \
         ../../main/tools_i2c.c \

--- a/test/host/mock_memory.c
+++ b/test/host/mock_memory.c
@@ -74,6 +74,20 @@ void mock_memory_fail_next_set(esp_err_t err)
     s_next_set_err = err;
 }
 
+size_t mock_memory_count(void)
+{
+    size_t count = 0;
+    int i;
+
+    for (i = 0; i < MOCK_MEMORY_SLOTS; i++) {
+        if (s_slots[i].in_use) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
 esp_err_t memory_init(void)
 {
     mock_memory_reset();
@@ -124,5 +138,11 @@ esp_err_t memory_delete(const char *key)
     }
 
     memset(&s_slots[slot], 0, sizeof(s_slots[slot]));
+    return ESP_OK;
+}
+
+esp_err_t memory_factory_reset(void)
+{
+    mock_memory_reset();
     return ESP_OK;
 }

--- a/test/host/mock_memory.h
+++ b/test/host/mock_memory.h
@@ -6,5 +6,6 @@
 void mock_memory_reset(void);
 void mock_memory_set_kv(const char *key, const char *value);
 void mock_memory_fail_next_set(esp_err_t err);
+size_t mock_memory_count(void);
 
 #endif // MOCK_MEMORY_H

--- a/test/host/test_agent.c
+++ b/test/host/test_agent.c
@@ -7,9 +7,11 @@
 
 #include "agent.h"
 #include "config.h"
+#include "local_admin.h"
 #include "messages.h"
 #include "mock_freertos.h"
 #include "mock_llm.h"
+#include "mock_memory.h"
 #include "mock_ratelimit.h"
 #include "mock_tools.h"
 #include "freertos/queue.h"
@@ -83,6 +85,7 @@ static void reset_state(void)
 {
     mock_freertos_reset();
     mock_llm_reset();
+    mock_memory_reset();
     mock_ratelimit_reset();
     mock_tools_reset();
     s_telegram_pause_calls = 0;
@@ -442,6 +445,186 @@ TEST(diag_command_rejects_invalid_args)
     ASSERT(mock_tools_execute_calls() == 0);
     ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
     ASSERT(strstr(text, "unknown /diag argument") != NULL);
+
+    vQueueDelete(channel_q);
+    return 0;
+}
+
+TEST(gpio_command_bypasses_llm_and_uses_tool)
+{
+    QueueHandle_t channel_q;
+    QueueHandle_t telegram_q;
+    char text[TELEGRAM_MAX_MSG_LEN];
+
+    reset_state();
+
+    channel_q = xQueueCreate(4, sizeof(channel_output_msg_t));
+    telegram_q = xQueueCreate(4, sizeof(telegram_msg_t));
+    ASSERT(channel_q != NULL);
+    ASSERT(telegram_q != NULL);
+    agent_test_set_queues(channel_q, telegram_q);
+
+    agent_test_process_message("/gpio all");
+    ASSERT(mock_llm_request_count() == 0);
+    ASSERT(mock_tools_execute_calls() == 1);
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT_STR_EQ(text, "mock tool executed");
+    ASSERT(recv_telegram_text(telegram_q, text, sizeof(text)) == 1);
+    ASSERT_STR_EQ(text, "mock tool executed");
+
+    agent_test_process_message("/stop");
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT(recv_telegram_text(telegram_q, text, sizeof(text)) == 1);
+    agent_test_process_message("/gpio 7");
+    ASSERT(mock_llm_request_count() == 0);
+    ASSERT(mock_tools_execute_calls() == 2);
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT_STR_EQ(text, "mock tool executed");
+    ASSERT(recv_telegram_text(telegram_q, text, sizeof(text)) == 1);
+    ASSERT_STR_EQ(text, "mock tool executed");
+
+    agent_test_process_message("/gpio 9 low");
+    ASSERT(mock_llm_request_count() == 0);
+    ASSERT(mock_tools_execute_calls() == 3);
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT_STR_EQ(text, "mock tool executed");
+    ASSERT(recv_telegram_text(telegram_q, text, sizeof(text)) == 1);
+    ASSERT_STR_EQ(text, "mock tool executed");
+
+    vQueueDelete(channel_q);
+    vQueueDelete(telegram_q);
+    return 0;
+}
+
+TEST(gpio_command_rejects_invalid_args)
+{
+    QueueHandle_t channel_q;
+    char text[CHANNEL_TX_BUF_SIZE];
+
+    reset_state();
+
+    channel_q = xQueueCreate(2, sizeof(channel_output_msg_t));
+    ASSERT(channel_q != NULL);
+    agent_test_set_queues(channel_q, NULL);
+
+    agent_test_process_message("/gpio nope");
+    ASSERT(mock_llm_request_count() == 0);
+    ASSERT(mock_tools_execute_calls() == 0);
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT(strstr(text, "unknown /gpio argument") != NULL);
+
+    agent_test_process_message("/gpio all extra");
+    ASSERT(mock_llm_request_count() == 0);
+    ASSERT(mock_tools_execute_calls() == 0);
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT(strstr(text, "/gpio all does not take extra arguments") != NULL);
+
+    agent_test_process_message("/gpio 9 sideways");
+    ASSERT(mock_llm_request_count() == 0);
+    ASSERT(mock_tools_execute_calls() == 0);
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT(strstr(text, "unknown GPIO state") != NULL);
+
+    vQueueDelete(channel_q);
+    return 0;
+}
+
+TEST(local_admin_commands_are_local_only)
+{
+    QueueHandle_t channel_q;
+    QueueHandle_t telegram_q;
+    char text[TELEGRAM_MAX_MSG_LEN];
+
+    reset_state();
+
+    channel_q = xQueueCreate(2, sizeof(channel_output_msg_t));
+    telegram_q = xQueueCreate(2, sizeof(telegram_msg_t));
+    ASSERT(channel_q != NULL);
+    ASSERT(telegram_q != NULL);
+    agent_test_set_queues(channel_q, telegram_q);
+
+    agent_test_process_message_for_chat("/wifi status", -100222333444LL);
+    ASSERT(mock_llm_request_count() == 0);
+    ASSERT(mock_tools_execute_calls() == 0);
+    ASSERT(recv_telegram_text(telegram_q, text, sizeof(text)) == 1);
+    ASSERT(strstr(text, "only available on the USB serial console") != NULL);
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT(strstr(text, "only available on the USB serial console") != NULL);
+    ASSERT(local_admin_test_last_action() == LOCAL_ADMIN_ACTION_NONE);
+
+    vQueueDelete(channel_q);
+    vQueueDelete(telegram_q);
+    return 0;
+}
+
+TEST(local_admin_commands_bypass_llm_and_report_state)
+{
+    QueueHandle_t channel_q;
+    char text[CHANNEL_TX_BUF_SIZE];
+
+    reset_state();
+
+    channel_q = xQueueCreate(4, sizeof(channel_output_msg_t));
+    ASSERT(channel_q != NULL);
+    agent_test_set_queues(channel_q, NULL);
+    local_admin_test_set_wifi_status("WiFi status: provisioned=yes safe_mode=no driver=started link=connected ssid=Trident ip=10.0.0.24 rssi=-77 last_reason=none");
+    local_admin_test_set_wifi_scan("WiFi scan: 2 APs visible (top 2)\n- Trident rssi=-77 auth=WPA2_PSK ch=6 (2437MHz)\n- Guest rssi=-88 auth=OPEN ch=1 (2412MHz)");
+    local_admin_set_safe_mode(true);
+    local_admin_set_device_configured(true);
+    mock_memory_set_kv("boot_count", "3");
+
+    agent_test_process_message("/wifi status");
+    ASSERT(mock_llm_request_count() == 0);
+    ASSERT(mock_tools_execute_calls() == 0);
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT(strstr(text, "ssid=Trident") != NULL);
+
+    agent_test_process_message("/wifi scan");
+    ASSERT(mock_llm_request_count() == 0);
+    ASSERT(mock_tools_execute_calls() == 0);
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT(strstr(text, "WiFi scan: 2 APs visible") != NULL);
+
+    agent_test_process_message("/bootcount");
+    ASSERT(mock_llm_request_count() == 0);
+    ASSERT(mock_tools_execute_calls() == 0);
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT(strstr(text, "persisted=3") != NULL);
+    ASSERT(strstr(text, "safe_mode=yes") != NULL);
+
+    vQueueDelete(channel_q);
+    return 0;
+}
+
+TEST(local_admin_reboot_and_factory_reset_commands)
+{
+    QueueHandle_t channel_q;
+    char text[CHANNEL_TX_BUF_SIZE];
+
+    reset_state();
+
+    channel_q = xQueueCreate(4, sizeof(channel_output_msg_t));
+    ASSERT(channel_q != NULL);
+    agent_test_set_queues(channel_q, NULL);
+    mock_memory_set_kv("wifi_ssid", "Trident");
+    mock_memory_set_kv("api_key", "test-key");
+
+    agent_test_process_message("/factory-reset");
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT(strstr(text, "Run /factory-reset confirm") != NULL);
+    ASSERT(local_admin_test_last_action() == LOCAL_ADMIN_ACTION_NONE);
+    ASSERT(mock_memory_count() == 2);
+
+    agent_test_process_message("/factory-reset confirm");
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT(strstr(text, "Factory reset confirmed") != NULL);
+    ASSERT(local_admin_test_last_action() == LOCAL_ADMIN_ACTION_FACTORY_RESET_REBOOT);
+    ASSERT(mock_memory_count() == 0);
+
+    agent_test_process_message("/reboot");
+    ASSERT(recv_channel_text(channel_q, text, sizeof(text)) == 1);
+    ASSERT_STR_EQ(text, "Rebooting...");
+    ASSERT(local_admin_test_last_action() == LOCAL_ADMIN_ACTION_REBOOT);
 
     vQueueDelete(channel_q);
     return 0;
@@ -809,6 +992,41 @@ int test_agent_all(void)
 
     printf("  diag_command_rejects_invalid_args... ");
     if (test_diag_command_rejects_invalid_args() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  gpio_command_bypasses_llm_and_uses_tool... ");
+    if (test_gpio_command_bypasses_llm_and_uses_tool() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  gpio_command_rejects_invalid_args... ");
+    if (test_gpio_command_rejects_invalid_args() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  local_admin_commands_are_local_only... ");
+    if (test_local_admin_commands_are_local_only() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  local_admin_commands_bypass_llm_and_report_state... ");
+    if (test_local_admin_commands_bypass_llm_and_report_state() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  local_admin_reboot_and_factory_reset_commands... ");
+    if (test_local_admin_reboot_and_factory_reset_commands() == 0) {
         printf("OK\n");
     } else {
         failures++;


### PR DESCRIPTION
## Summary
- add a USB-local admin plane for /gpio, /diag, /reboot, /wifi, /bootcount, and guarded /factory-reset commands
- route those commands ahead of the LLM path, keep them available in safe mode, and reject them from Telegram/web relay callers
- document the new local admin console in README and the docs site, including a dedicated Chapter 9 and refreshed size-breakdown values on the touched overview pages

## Testing
- ./scripts/test.sh host
- live board verification over USB serial on /dev/cu.usbmodem1101 for /bootcount, /wifi status, /wifi scan, /factory-reset, and /reboot
- intentionally did not run /factory-reset confirm on hardware because it erases NVS immediately