### PR TITLE
feat: add typed BH1750 read tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Non-interactive install:
 - Built-in + user-defined tools
 - For brand-new built-in capabilities, add a firmware tool (C handler + registry entry) via the Build Your Own Tool docs.
 - Runtime diagnostics via `get_diagnostics` (quick/runtime/memory/rates/time/all scopes)
-- GPIO, DHT, and I2C control with guardrails (including `gpio_read_all`, `i2c_scan`, `i2c_read`/`i2c_write`, and `dht_read`)
+- GPIO, DHT, BH1750, and I2C control with guardrails (including `gpio_read_all`, `i2c_scan`, `i2c_read`/`i2c_write`, `bh1750_read`, and `dht_read`)
 - USB local admin console for recovery, safe mode, and pre-network bring-up
 - Persistent memory across reboots
 - Persona options: `neutral`, `friendly`, `technical`, `witty`

--- a/docs-site/build-your-own-tool.html
+++ b/docs-site/build-your-own-tool.html
@@ -132,7 +132,7 @@ Agent: Creates a tool using the remembered lighting pin instead of asking you to
         <section class="section">
           <h2>Approach 2: Firmware Tool (C Code + Reflash)</h2>
           <p>Use this path when you need behavior that is not a composition of existing tools (new I/O paths, strict schemas, deterministic validation, special error handling).</p>
-          <p class="inline-note">Example boundary: a user tool can compose <code>i2c_write_read</code> or <code>dht_read</code>, but it cannot invent a new bus or timing-sensitive sensor driver. That belongs in firmware.</p>
+          <p class="inline-note">Example boundary: a user tool can compose <code>bh1750_read</code>, <code>i2c_write_read</code>, or <code>dht_read</code>, but it cannot invent a new sensor driver or bus implementation. That belongs in firmware.</p>
           <ol>
             <li>Implement handler logic in <code>main/tools_*.c</code> with signature <code>bool handler(const cJSON *input, char *result, size_t result_len)</code>.</li>
             <li>Declare it in <code>main/tools_handlers.h</code>.</li>

--- a/docs-site/reference/README_COMPLETE.md
+++ b/docs-site/reference/README_COMPLETE.md
@@ -246,6 +246,7 @@ Full reference: [Local Admin Console](docs-site/local-admin.html)
 | `i2c_write` | Write hex bytes to a 7-bit I2C device |
 | `i2c_read` | Read raw bytes from a 7-bit I2C device |
 | `i2c_write_read` | Write bytes, then read bytes from the same I2C device |
+| `bh1750_read` | Read ambient light from a BH1750 in lux |
 | `dht_read` | Read DHT11/DHT22 humidity and temperature on one GPIO pin |
 | `memory_set` | Store persistent user key-value (`u_*` keys only) |
 | `memory_get` | Retrieve stored user value (`u_*` keys only) |
@@ -269,6 +270,8 @@ Built-in firmware update tools are temporarily disabled and marked as coming soo
 `i2c_scan`, `i2c_write`, `i2c_read`, and `i2c_write_read` require `sda_pin` and `scl_pin` inputs (plus optional `frequency_hz`).
 I2C addresses are 7-bit decimal integers in JSON. For example, `118` means `0x76`.
 
+`bh1750_read` is a typed I2C wrapper for the BH1750 ambient light sensor. It requires `sda_pin` and `scl_pin`, defaults to address `35` (`0x23`), and also supports `92` (`0x5C`).
+
 Example I2C scan:
 
 ```json
@@ -285,6 +288,12 @@ Example register write via I2C:
 
 ```json
 {"sda_pin":8,"scl_pin":9,"address":118,"data_hex":"0xF4 0x2E"}
+```
+
+Example BH1750 read:
+
+```json
+{"sda_pin":8,"scl_pin":9}
 ```
 
 `dht_read` is separate because DHT sensors do not use I2C. They use a timing-sensitive single-wire protocol on one GPIO pin.

--- a/docs-site/tools.html
+++ b/docs-site/tools.html
@@ -61,7 +61,7 @@
               <tr><th>Group</th><th>Tools</th><th>Use</th></tr>
             </thead>
             <tbody>
-              <tr><td>Hardware</td><td><code>gpio_write</code>, <code>gpio_read</code>, <code>gpio_read_all</code>, <code>delay</code>, <code>i2c_scan</code>, <code>i2c_write</code>, <code>i2c_read</code>, <code>i2c_write_read</code>, <code>dht_read</code></td><td>Pins, timing-sensitive sensors, and generic I2C bus transactions (including one-call full GPIO state reads).</td></tr>
+              <tr><td>Hardware</td><td><code>gpio_write</code>, <code>gpio_read</code>, <code>gpio_read_all</code>, <code>delay</code>, <code>i2c_scan</code>, <code>i2c_write</code>, <code>i2c_read</code>, <code>i2c_write_read</code>, <code>bh1750_read</code>, <code>dht_read</code></td><td>Pins, typed sensor reads, timing-sensitive sensors, and generic I2C bus transactions (including one-call full GPIO state reads).</td></tr>
               <tr><td>Memory</td><td><code>memory_set</code>, <code>memory_get</code>, <code>memory_list</code>, <code>memory_delete</code></td><td>Persistent user state (<code>u_*</code> keys).</td></tr>
               <tr><td>Schedules</td><td><code>cron_set</code>, <code>cron_list</code>, <code>cron_delete</code></td><td>Periodic, daily, and one-shot jobs.</td></tr>
               <tr><td>Clock</td><td><code>get_time</code>, <code>set_timezone</code>, <code>get_timezone</code></td><td>Timezone-aware schedule behavior.</td></tr>
@@ -80,8 +80,10 @@
             <li><code>i2c_write</code> sends space-separated hex bytes to one 7-bit address.</li>
             <li><code>i2c_read</code> reads raw bytes from one 7-bit address.</li>
             <li><code>i2c_write_read</code> writes first, then reads from the same address. Use this for register reads.</li>
+            <li><code>bh1750_read</code> is a typed ambient-light read for the BH1750. It defaults to address <code>35</code> (<code>0x23</code>) and also supports <code>92</code> (<code>0x5C</code>).</li>
           </ul>
           <pre>{"sda_pin":8,"scl_pin":9,"address":118,"write_hex":"0xD0","read_length":1}</pre>
+          <pre>{"sda_pin":8,"scl_pin":9}</pre>
           <pre>{"pin":5,"model":"dht22"}</pre>
           <p class="inline-note">Hex payload fields accept space-separated bytes such as <code>0xF4 0x2E</code>. Tool JSON uses decimal I2C addresses, so <code>118</code> means <code>0x76</code>.</p>
         </section>

--- a/docs-site/use-cases.html
+++ b/docs-site/use-cases.html
@@ -73,7 +73,7 @@
             <tbody>
               <tr><td>Lab bring-up checklist</td><td>Runs a staged startup script: set GPIO rails, wait, verify sensor pins, report health.</td><td>One chat command can control real sequencing and report exact current state.</td></tr>
               <tr><td>Greenhouse helper</td><td>Schedules watering, stores moisture notes, toggles relays, and reports timing.</td><td>State and schedules persist locally; no separate home-automation hub required.</td></tr>
-              <tr><td>Sensor bench console</td><td>Reads DHT probes, scans I2C buses, and performs register reads/writes while you are standing at the hardware.</td><td>You can discover wiring mistakes and validate sensors from the same device that is attached to the bus.</td></tr>
+              <tr><td>Sensor bench console</td><td>Reads DHT probes, checks BH1750 light levels, scans I2C buses, and performs register reads/writes while you are standing at the hardware.</td><td>You can discover wiring mistakes and validate both typed sensors and raw bus traffic from the same device that is attached to the bus.</td></tr>
               <tr><td>Workshop routine assistant</td><td>Starts timed reminders for recurring bench tasks and equipment checks.</td><td>Reminders and actions are tied to the same device that controls outputs.</td></tr>
               <tr><td>Field test rig assistant</td><td>Creates one-shot test routines, logs outcomes in memory keys, and replays known-good actions.</td><td>Useful when you need repeatable actions from natural language while standing at hardware.</td></tr>
               <tr><td>Power/load cycling</td><td>Switches circuits with delay windows and periodic checks, then summarizes what happened.</td><td>Low-friction orchestration where command, execution, and telemetry live together.</td></tr>
@@ -96,7 +96,7 @@
           <h2>Unique Because It Runs Here</h2>
           <p>zclaw is interesting because it is constrained and embodied:</p>
           <ul>
-            <li><strong>Embodied:</strong> it can immediately reach hardware through GPIO, DHT sensor reads, and generic I2C bus transactions. It can go around with you.</li>
+            <li><strong>Embodied:</strong> it can immediately reach hardware through GPIO, typed sensor reads like DHT and BH1750, and generic I2C bus transactions. It can go around with you.</li>
             <li><strong>Stateful:</strong> memory keys and persona stay on the device</li>
             <li><strong>Schedulable:</strong> natural language can produce persistent timed behavior.</li>
             <li><strong>Inspectable:</strong> logs and built-in health/version tools make behavior debuggable.</li>
@@ -128,6 +128,7 @@
 "Run bench_shutdown."
 
 "Scan the I2C bus on SDA 8, SCL 9."
+"Read the BH1750 light sensor on SDA 8, SCL 9."
 "Read the DHT22 sensor on GPIO 5."
 
 "At 8:15 every day, remind me to check the plants."

--- a/main/builtin_tools.def
+++ b/main/builtin_tools.def
@@ -40,6 +40,10 @@ TOOL_ENTRY("i2c_write_read",
            "Write hex bytes, then read from the same I2C address.",
            "{\"type\":\"object\",\"properties\":{\"sda_pin\":{\"type\":\"integer\"},\"scl_pin\":{\"type\":\"integer\"},\"address\":{\"type\":\"integer\"},\"write_hex\":{\"type\":\"string\"},\"read_length\":{\"type\":\"integer\"},\"frequency_hz\":{\"type\":\"integer\"}},\"required\":[\"sda_pin\",\"scl_pin\",\"address\",\"write_hex\",\"read_length\"]}",
            tools_i2c_write_read_handler)
+TOOL_ENTRY("bh1750_read",
+           "Read ambient light from a BH1750 sensor in lux.",
+           "{\"type\":\"object\",\"properties\":{\"sda_pin\":{\"type\":\"integer\"},\"scl_pin\":{\"type\":\"integer\"},\"address\":{\"type\":\"integer\"},\"frequency_hz\":{\"type\":\"integer\"}},\"required\":[\"sda_pin\",\"scl_pin\"]}",
+           tools_bh1750_read_handler)
 TOOL_ENTRY("dht_read",
            "Read a DHT11 or DHT22 sensor.",
            "{\"type\":\"object\",\"properties\":{\"pin\":{\"type\":\"integer\"},\"model\":{\"type\":\"string\",\"enum\":[\"dht11\",\"dht22\"]},\"retries\":{\"type\":\"integer\"}},\"required\":[\"pin\",\"model\"]}",

--- a/main/tools_handlers.h
+++ b/main/tools_handlers.h
@@ -20,6 +20,7 @@ bool tools_i2c_scan_handler(const cJSON *input, char *result, size_t result_len)
 bool tools_i2c_write_handler(const cJSON *input, char *result, size_t result_len);
 bool tools_i2c_read_handler(const cJSON *input, char *result, size_t result_len);
 bool tools_i2c_write_read_handler(const cJSON *input, char *result, size_t result_len);
+bool tools_bh1750_read_handler(const cJSON *input, char *result, size_t result_len);
 bool tools_dht_read_handler(const cJSON *input, char *result, size_t result_len);
 
 // Memory

--- a/main/tools_i2c.c
+++ b/main/tools_i2c.c
@@ -4,6 +4,7 @@
 #include "driver/i2c.h"
 #include "esp_err.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include <ctype.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -20,6 +21,11 @@
 #define I2C_ADDR_TIMEOUT_MS          25
 #define I2C_IO_TIMEOUT_MS            1000
 #define I2C_MAX_DATA_BYTES           64
+#define BH1750_DEFAULT_ADDRESS       0x23
+#define BH1750_ALT_ADDRESS           0x5C
+#define BH1750_POWER_ON              0x01
+#define BH1750_ONE_TIME_H_RES_MODE   0x20
+#define BH1750_MEASUREMENT_DELAY_MS  180
 
 typedef enum {
     I2C_TOOL_WRITE = 0,
@@ -57,6 +63,31 @@ static bool parse_address(const cJSON *input, uint8_t *address, char *result, si
     }
     if (address_json->valueint < I2C_ADDR_FIRST || address_json->valueint > I2C_ADDR_LAST) {
         snprintf(result, result_len, "Error: address must be %d-%d (7-bit I2C)", I2C_ADDR_FIRST, I2C_ADDR_LAST);
+        return false;
+    }
+    *address = (uint8_t)address_json->valueint;
+    return true;
+}
+
+static bool parse_optional_address(const cJSON *input,
+                                   const char *field_name,
+                                   uint8_t default_address,
+                                   uint8_t *address,
+                                   char *result,
+                                   size_t result_len)
+{
+    cJSON *address_json = cJSON_GetObjectItem(input, field_name);
+
+    if (!address_json) {
+        *address = default_address;
+        return true;
+    }
+    if (!cJSON_IsNumber(address_json)) {
+        snprintf(result, result_len, "Error: %s must be a number", field_name);
+        return false;
+    }
+    if (address_json->valueint < I2C_ADDR_FIRST || address_json->valueint > I2C_ADDR_LAST) {
+        snprintf(result, result_len, "Error: %s must be %d-%d (7-bit I2C)", field_name, I2C_ADDR_FIRST, I2C_ADDR_LAST);
         return false;
     }
     *address = (uint8_t)address_json->valueint;
@@ -329,6 +360,91 @@ static bool execute_i2c_transfer(const cJSON *input,
              (int)read_len,
              (int)write_len,
              hex_buffer);
+    return true;
+}
+
+bool tools_bh1750_read_handler(const cJSON *input, char *result, size_t result_len)
+{
+    uint8_t address = BH1750_DEFAULT_ADDRESS;
+    uint8_t power_on = BH1750_POWER_ON;
+    uint8_t one_time_mode = BH1750_ONE_TIME_H_RES_MODE;
+    uint8_t read_buffer[2] = {0};
+    uint16_t raw_lux = 0;
+    uint32_t lux_tenths = 0;
+    int sda_pin;
+    int scl_pin;
+    int frequency_hz = I2C_DEFAULT_FREQ_HZ;
+    esp_err_t err;
+
+    if (!parse_bus_pins(input, &sda_pin, &scl_pin, result, result_len) ||
+        !parse_optional_address(input, "address", BH1750_DEFAULT_ADDRESS, &address, result, result_len) ||
+        !parse_frequency(input, &frequency_hz, result, result_len)) {
+        return false;
+    }
+    if (address != BH1750_DEFAULT_ADDRESS && address != BH1750_ALT_ADDRESS) {
+        snprintf(result,
+                 result_len,
+                 "Error: BH1750 address must be %d (0x%02X) or %d (0x%02X)",
+                 BH1750_DEFAULT_ADDRESS,
+                 BH1750_DEFAULT_ADDRESS,
+                 BH1750_ALT_ADDRESS,
+                 BH1750_ALT_ADDRESS);
+        return false;
+    }
+    if (!init_i2c_master(sda_pin, scl_pin, frequency_hz, result, result_len)) {
+        return false;
+    }
+
+    err = i2c_master_write_to_device(
+        I2C_TOOL_PORT,
+        address,
+        &power_on,
+        1,
+        pdMS_TO_TICKS(I2C_IO_TIMEOUT_MS)
+    );
+    if (err != ESP_OK) {
+        i2c_driver_delete(I2C_TOOL_PORT);
+        snprintf(result, result_len, "Error: bh1750_read power on failed (%s)", esp_err_to_name(err));
+        return false;
+    }
+
+    err = i2c_master_write_to_device(
+        I2C_TOOL_PORT,
+        address,
+        &one_time_mode,
+        1,
+        pdMS_TO_TICKS(I2C_IO_TIMEOUT_MS)
+    );
+    if (err != ESP_OK) {
+        i2c_driver_delete(I2C_TOOL_PORT);
+        snprintf(result, result_len, "Error: bh1750_read start measurement failed (%s)", esp_err_to_name(err));
+        return false;
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(BH1750_MEASUREMENT_DELAY_MS));
+
+    err = i2c_master_read_from_device(
+        I2C_TOOL_PORT,
+        address,
+        read_buffer,
+        sizeof(read_buffer),
+        pdMS_TO_TICKS(I2C_IO_TIMEOUT_MS)
+    );
+    i2c_driver_delete(I2C_TOOL_PORT);
+    if (err != ESP_OK) {
+        snprintf(result, result_len, "Error: bh1750_read read failed (%s)", esp_err_to_name(err));
+        return false;
+    }
+
+    raw_lux = (uint16_t)(((uint16_t)read_buffer[0] << 8) | read_buffer[1]);
+    lux_tenths = (uint32_t)((raw_lux * 100U + 6U) / 12U);
+
+    snprintf(result,
+             result_len,
+             "BH1750 0x%02X: %lu.%01lu lux",
+             address,
+             (unsigned long)(lux_tenths / 10U),
+             (unsigned long)(lux_tenths % 10U));
     return true;
 }
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -63,6 +63,7 @@ run_host_tests() {
         test_agent.c \
         test_tools_gpio_policy.c \
         test_tools_i2c_policy.c \
+        test_tools_bh1750.c \
         test_tools_dht.c \
         test_builtin_tools_registry.c \
         test_tools_system_diag.c \

--- a/test/api/provider_harness.py
+++ b/test/api/provider_harness.py
@@ -17,7 +17,7 @@ except ModuleNotFoundError:
 
 SYSTEM_PROMPT = """You are zclaw, an AI agent running on an ESP32 microcontroller. \
 You have 400KB of RAM and run on bare metal with FreeRTOS. \
-You can control GPIO pins, talk to I2C devices, read supported sensors, store persistent memories, and set schedules. \
+You can control GPIO pins, talk to I2C devices, read supported sensors like DHT and BH1750, store persistent memories, and set schedules. \
 Be concise - you're on a tiny chip. \
 Use your tools to control hardware, remember things, and automate tasks. \
 Users can create custom tools with create_tool. When you call a custom tool, \
@@ -116,6 +116,20 @@ TOOLS = [
                 "frequency_hz": {"type": "integer", "description": "I2C bus speed in Hz (optional, default 100000)"},
             },
             "required": ["sda_pin", "scl_pin", "address", "write_hex", "read_length"],
+        },
+    },
+    {
+        "name": "bh1750_read",
+        "description": "Read ambient light from a BH1750 sensor in lux. This is a typed I2C sensor read.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "sda_pin": {"type": "integer", "description": "GPIO pin for SDA (subject to GPIO Tool Safety policy)"},
+                "scl_pin": {"type": "integer", "description": "GPIO pin for SCL (subject to GPIO Tool Safety policy)"},
+                "address": {"type": "integer", "description": "Optional BH1750 address: 35 (0x23) or 92 (0x5C)"},
+                "frequency_hz": {"type": "integer", "description": "I2C bus speed in Hz (optional, default 100000)"},
+            },
+            "required": ["sda_pin", "scl_pin"],
         },
     },
     {
@@ -276,6 +290,7 @@ MOCK_RESULTS = {
     "i2c_read": lambda inp: f"Read {inp.get('read_length')} byte(s) from I2C address {inp.get('address')}: 0x00",
     "i2c_write_read": lambda inp: f"Read {inp.get('read_length')} byte(s) from I2C address {inp.get('address')} after writing bytes: 0x00",
     "dht_read": lambda inp: f"{inp.get('model', 'dht11').upper()} on GPIO {inp.get('pin')}: humidity=55.0%, temperature=24.0 C",
+    "bh1750_read": lambda inp: f"BH1750 0x{inp.get('address', 35):02X}: 184.0 lux",
     "memory_set": lambda inp: f"Saved: {inp.get('key')} = {inp.get('value')}",
     "memory_get": lambda inp: f"{inp.get('key')} = example_value",
     "memory_list": lambda inp: "Stored keys: user_name, last_water",

--- a/test/host/driver/i2c.h
+++ b/test/host/driver/i2c.h
@@ -54,15 +54,20 @@ esp_err_t i2c_master_write_read_device(i2c_port_t i2c_num,
 void i2c_test_reset(void);
 void i2c_test_set_cmd_begin_result(esp_err_t result);
 void i2c_test_set_write_to_device_result(esp_err_t result);
+bool i2c_test_push_write_to_device_result(esp_err_t result);
 void i2c_test_set_read_from_device_result(esp_err_t result);
 void i2c_test_set_write_read_device_result(esp_err_t result);
 void i2c_test_set_read_data(const uint8_t *data, size_t len);
 int i2c_test_get_param_config_calls(void);
 int i2c_test_get_driver_install_calls(void);
 int i2c_test_get_driver_delete_calls(void);
+int i2c_test_get_write_to_device_calls(void);
 uint8_t i2c_test_get_last_address(void);
 size_t i2c_test_get_last_write_length(void);
 size_t i2c_test_get_last_read_length(void);
 uint8_t i2c_test_get_last_write_byte(size_t index);
+uint8_t i2c_test_get_write_to_device_address(size_t index);
+size_t i2c_test_get_write_to_device_length(size_t index);
+uint8_t i2c_test_get_write_to_device_byte(size_t call_index, size_t byte_index);
 
 #endif  // DRIVER_I2C_H

--- a/test/host/mock_i2c.c
+++ b/test/host/mock_i2c.c
@@ -4,12 +4,17 @@
 #include <stddef.h>
 
 #define I2C_TEST_MAX_BYTES 64
+#define I2C_TEST_MAX_WRITES 8
 
 static int s_param_config_calls = 0;
 static int s_driver_install_calls = 0;
 static int s_driver_delete_calls = 0;
+static int s_write_to_device_calls = 0;
 static esp_err_t s_cmd_begin_result = ESP_FAIL;
 static esp_err_t s_write_to_device_result = ESP_OK;
+static esp_err_t s_write_to_device_results[I2C_TEST_MAX_WRITES];
+static int s_write_to_device_result_count = 0;
+static int s_write_to_device_result_index = 0;
 static esp_err_t s_read_from_device_result = ESP_OK;
 static esp_err_t s_write_read_device_result = ESP_OK;
 static uint8_t s_read_data[I2C_TEST_MAX_BYTES];
@@ -18,14 +23,21 @@ static uint8_t s_last_address = 0;
 static uint8_t s_last_write[I2C_TEST_MAX_BYTES];
 static size_t s_last_write_len = 0;
 static size_t s_last_read_len = 0;
+static uint8_t s_write_addresses[I2C_TEST_MAX_WRITES];
+static uint8_t s_write_history[I2C_TEST_MAX_WRITES][I2C_TEST_MAX_BYTES];
+static size_t s_write_history_len[I2C_TEST_MAX_WRITES];
 
 void i2c_test_reset(void)
 {
     s_param_config_calls = 0;
     s_driver_install_calls = 0;
     s_driver_delete_calls = 0;
+    s_write_to_device_calls = 0;
     s_cmd_begin_result = ESP_FAIL;
     s_write_to_device_result = ESP_OK;
+    memset(s_write_to_device_results, 0, sizeof(s_write_to_device_results));
+    s_write_to_device_result_count = 0;
+    s_write_to_device_result_index = 0;
     s_read_from_device_result = ESP_OK;
     s_write_read_device_result = ESP_OK;
     memset(s_read_data, 0, sizeof(s_read_data));
@@ -34,6 +46,9 @@ void i2c_test_reset(void)
     memset(s_last_write, 0, sizeof(s_last_write));
     s_last_write_len = 0;
     s_last_read_len = 0;
+    memset(s_write_addresses, 0, sizeof(s_write_addresses));
+    memset(s_write_history, 0, sizeof(s_write_history));
+    memset(s_write_history_len, 0, sizeof(s_write_history_len));
 }
 
 void i2c_test_set_cmd_begin_result(esp_err_t result)
@@ -44,6 +59,15 @@ void i2c_test_set_cmd_begin_result(esp_err_t result)
 void i2c_test_set_write_to_device_result(esp_err_t result)
 {
     s_write_to_device_result = result;
+}
+
+bool i2c_test_push_write_to_device_result(esp_err_t result)
+{
+    if (s_write_to_device_result_count >= I2C_TEST_MAX_WRITES) {
+        return false;
+    }
+    s_write_to_device_results[s_write_to_device_result_count++] = result;
+    return true;
 }
 
 void i2c_test_set_read_from_device_result(esp_err_t result)
@@ -85,6 +109,11 @@ int i2c_test_get_driver_delete_calls(void)
     return s_driver_delete_calls;
 }
 
+int i2c_test_get_write_to_device_calls(void)
+{
+    return s_write_to_device_calls;
+}
+
 uint8_t i2c_test_get_last_address(void)
 {
     return s_last_address;
@@ -106,6 +135,32 @@ uint8_t i2c_test_get_last_write_byte(size_t index)
         return 0;
     }
     return s_last_write[index];
+}
+
+uint8_t i2c_test_get_write_to_device_address(size_t index)
+{
+    if (index >= (size_t)s_write_to_device_calls || index >= I2C_TEST_MAX_WRITES) {
+        return 0;
+    }
+    return s_write_addresses[index];
+}
+
+size_t i2c_test_get_write_to_device_length(size_t index)
+{
+    if (index >= (size_t)s_write_to_device_calls || index >= I2C_TEST_MAX_WRITES) {
+        return 0;
+    }
+    return s_write_history_len[index];
+}
+
+uint8_t i2c_test_get_write_to_device_byte(size_t call_index, size_t byte_index)
+{
+    if (call_index >= (size_t)s_write_to_device_calls ||
+        call_index >= I2C_TEST_MAX_WRITES ||
+        byte_index >= s_write_history_len[call_index]) {
+        return 0;
+    }
+    return s_write_history[call_index][byte_index];
 }
 
 esp_err_t i2c_param_config(i2c_port_t i2c_num, const i2c_config_t *i2c_conf)
@@ -179,6 +234,7 @@ esp_err_t i2c_master_write_to_device(i2c_port_t i2c_num,
                                      uint32_t ticks_to_wait)
 {
     size_t copy_len = write_size;
+    esp_err_t result = s_write_to_device_result;
 
     (void)i2c_num;
     (void)ticks_to_wait;
@@ -192,7 +248,18 @@ esp_err_t i2c_master_write_to_device(i2c_port_t i2c_num,
     if (write_buffer && copy_len > 0) {
         memcpy(s_last_write, write_buffer, copy_len);
     }
-    return s_write_to_device_result;
+    if (s_write_to_device_calls < I2C_TEST_MAX_WRITES) {
+        s_write_addresses[s_write_to_device_calls] = device_address;
+        s_write_history_len[s_write_to_device_calls] = copy_len;
+        if (write_buffer && copy_len > 0) {
+            memcpy(s_write_history[s_write_to_device_calls], write_buffer, copy_len);
+        }
+    }
+    s_write_to_device_calls++;
+    if (s_write_to_device_result_index < s_write_to_device_result_count) {
+        result = s_write_to_device_results[s_write_to_device_result_index++];
+    }
+    return result;
 }
 
 esp_err_t i2c_master_read_from_device(i2c_port_t i2c_num,

--- a/test/host/test_builtin_tools_registry.c
+++ b/test/host/test_builtin_tools_registry.c
@@ -88,6 +88,7 @@ TEST(required_core_tools_exist)
         "i2c_write",
         "i2c_read",
         "i2c_write_read",
+        "bh1750_read",
         "dht_read",
         "memory_set",
         "cron_set",

--- a/test/host/test_runner.c
+++ b/test/host/test_runner.c
@@ -20,6 +20,7 @@ extern int test_telegram_http_diag_all(void);
 extern int test_agent_all(void);
 extern int test_tools_gpio_policy_all(void);
 extern int test_tools_i2c_policy_all(void);
+extern int test_tools_bh1750_all(void);
 extern int test_tools_dht_all(void);
 extern int test_builtin_tools_registry_all(void);
 extern int test_tools_system_diag_all(void);
@@ -48,6 +49,7 @@ int main(int argc, char *argv[])
     failures += test_agent_all();
     failures += test_tools_gpio_policy_all();
     failures += test_tools_i2c_policy_all();
+    failures += test_tools_bh1750_all();
     failures += test_tools_dht_all();
     failures += test_builtin_tools_registry_all();
     failures += test_tools_system_diag_all();

--- a/test/host/test_tools_bh1750.c
+++ b/test/host/test_tools_bh1750.c
@@ -1,0 +1,212 @@
+/*
+ * Host tests for typed BH1750 ambient light reads.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <cjson/cJSON.h>
+
+#include "driver/i2c.h"
+#include "mock_freertos.h"
+#include "tools_handlers.h"
+
+#define TEST(name) static int test_##name(void)
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        printf("  FAIL: %s (line %d)\n", #cond, __LINE__); \
+        return 1; \
+    } \
+} while (0)
+#define ASSERT_STR_CONTAINS(haystack, needle) do { \
+    if (strstr((haystack), (needle)) == NULL) { \
+        printf("  FAIL: expected substring '%s' in '%s' (line %d)\n", (needle), (haystack), __LINE__); \
+        return 1; \
+    } \
+} while (0)
+
+TEST(handler_defaults_to_primary_address_and_formats_lux)
+{
+    cJSON *input = cJSON_Parse("{\"sda_pin\":4,\"scl_pin\":5}");
+    char result[128] = {0};
+    const uint8_t read_data[2] = {0x01, 0xC2};
+
+    ASSERT(input != NULL);
+    i2c_test_reset();
+    mock_freertos_reset();
+    i2c_test_set_read_data(read_data, sizeof(read_data));
+    i2c_test_set_write_to_device_result(ESP_OK);
+    i2c_test_set_read_from_device_result(ESP_OK);
+
+    ASSERT(tools_bh1750_read_handler(input, result, sizeof(result)));
+    ASSERT_STR_CONTAINS(result, "BH1750 0x23");
+    ASSERT_STR_CONTAINS(result, "375.0 lux");
+    ASSERT(i2c_test_get_write_to_device_calls() == 2);
+    ASSERT(i2c_test_get_write_to_device_address(0) == 0x23);
+    ASSERT(i2c_test_get_write_to_device_length(0) == 1);
+    ASSERT(i2c_test_get_write_to_device_byte(0, 0) == 0x01);
+    ASSERT(i2c_test_get_write_to_device_address(1) == 0x23);
+    ASSERT(i2c_test_get_write_to_device_length(1) == 1);
+    ASSERT(i2c_test_get_write_to_device_byte(1, 0) == 0x20);
+    ASSERT(i2c_test_get_last_read_length() == 2);
+    ASSERT(i2c_test_get_driver_delete_calls() == 2);
+    ASSERT(mock_freertos_delay_count() == 1);
+    ASSERT(mock_freertos_delay_at(0) == pdMS_TO_TICKS(180));
+
+    cJSON_Delete(input);
+    return 0;
+}
+
+TEST(handler_accepts_alternate_address)
+{
+    cJSON *input = cJSON_Parse("{\"sda_pin\":4,\"scl_pin\":5,\"address\":92}");
+    char result[128] = {0};
+    const uint8_t read_data[2] = {0x00, 0x78};
+
+    ASSERT(input != NULL);
+    i2c_test_reset();
+    mock_freertos_reset();
+    i2c_test_set_read_data(read_data, sizeof(read_data));
+
+    ASSERT(tools_bh1750_read_handler(input, result, sizeof(result)));
+    ASSERT_STR_CONTAINS(result, "BH1750 0x5C");
+    ASSERT(i2c_test_get_write_to_device_address(0) == 0x5C);
+    ASSERT(i2c_test_get_write_to_device_address(1) == 0x5C);
+    ASSERT(i2c_test_get_driver_delete_calls() == 2);
+
+    cJSON_Delete(input);
+    return 0;
+}
+
+TEST(handler_rejects_unsupported_address_before_i2c_init)
+{
+    cJSON *input = cJSON_Parse("{\"sda_pin\":4,\"scl_pin\":5,\"address\":64}");
+    char result[128] = {0};
+
+    ASSERT(input != NULL);
+    i2c_test_reset();
+    mock_freertos_reset();
+
+    ASSERT(!tools_bh1750_read_handler(input, result, sizeof(result)));
+    ASSERT_STR_CONTAINS(result, "BH1750 address must be");
+    ASSERT(i2c_test_get_param_config_calls() == 0);
+    ASSERT(i2c_test_get_driver_install_calls() == 0);
+    ASSERT(mock_freertos_delay_count() == 0);
+
+    cJSON_Delete(input);
+    return 0;
+}
+
+TEST(handler_reports_power_on_failure)
+{
+    cJSON *input = cJSON_Parse("{\"sda_pin\":4,\"scl_pin\":5}");
+    char result[128] = {0};
+
+    ASSERT(input != NULL);
+    i2c_test_reset();
+    mock_freertos_reset();
+    i2c_test_set_write_to_device_result(ESP_FAIL);
+
+    ASSERT(!tools_bh1750_read_handler(input, result, sizeof(result)));
+    ASSERT_STR_CONTAINS(result, "power on failed");
+    ASSERT(i2c_test_get_write_to_device_calls() == 1);
+    ASSERT(i2c_test_get_driver_delete_calls() == 2);
+    ASSERT(mock_freertos_delay_count() == 0);
+
+    cJSON_Delete(input);
+    return 0;
+}
+
+TEST(handler_reports_measurement_start_failure)
+{
+    cJSON *input = cJSON_Parse("{\"sda_pin\":4,\"scl_pin\":5}");
+    char result[128] = {0};
+
+    ASSERT(input != NULL);
+    i2c_test_reset();
+    mock_freertos_reset();
+    ASSERT(i2c_test_push_write_to_device_result(ESP_OK));
+    ASSERT(i2c_test_push_write_to_device_result(ESP_FAIL));
+
+    ASSERT(!tools_bh1750_read_handler(input, result, sizeof(result)));
+    ASSERT_STR_CONTAINS(result, "start measurement failed");
+    ASSERT(i2c_test_get_write_to_device_calls() == 2);
+    ASSERT(i2c_test_get_driver_delete_calls() == 2);
+    ASSERT(mock_freertos_delay_count() == 0);
+
+    cJSON_Delete(input);
+    return 0;
+}
+
+TEST(handler_reports_read_failure_after_delay)
+{
+    cJSON *input = cJSON_Parse("{\"sda_pin\":4,\"scl_pin\":5}");
+    char result[128] = {0};
+
+    ASSERT(input != NULL);
+    i2c_test_reset();
+    mock_freertos_reset();
+    i2c_test_set_write_to_device_result(ESP_OK);
+    i2c_test_set_read_from_device_result(ESP_FAIL);
+
+    ASSERT(!tools_bh1750_read_handler(input, result, sizeof(result)));
+    ASSERT_STR_CONTAINS(result, "read failed");
+    ASSERT(i2c_test_get_write_to_device_calls() == 2);
+    ASSERT(i2c_test_get_driver_delete_calls() == 2);
+    ASSERT(mock_freertos_delay_count() == 1);
+    ASSERT(mock_freertos_delay_at(0) == pdMS_TO_TICKS(180));
+
+    cJSON_Delete(input);
+    return 0;
+}
+
+int test_tools_bh1750_all(void)
+{
+    int failures = 0;
+
+    printf("\nBH1750 Tool Tests:\n");
+
+    printf("  handler_defaults_to_primary_address_and_formats_lux... ");
+    if (test_handler_defaults_to_primary_address_and_formats_lux() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  handler_accepts_alternate_address... ");
+    if (test_handler_accepts_alternate_address() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  handler_rejects_unsupported_address_before_i2c_init... ");
+    if (test_handler_rejects_unsupported_address_before_i2c_init() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  handler_reports_power_on_failure... ");
+    if (test_handler_reports_power_on_failure() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  handler_reports_measurement_start_failure... ");
+    if (test_handler_reports_measurement_start_failure() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    printf("  handler_reports_read_failure_after_delay... ");
+    if (test_handler_reports_read_failure_after_delay() == 0) {
+        printf("OK\n");
+    } else {
+        failures++;
+    }
+
+    return failures;
+}


### PR DESCRIPTION
## Summary
- add a first-class `bh1750_read` built-in tool for typed ambient light reads over I2C
- extend host I2C mocks/tests to cover BH1750 success and failure paths, including distinct measurement-start failure coverage
- update user-facing docs and the provider harness so BH1750 shows up wherever supported tools are listed

## Details
- `bh1750_read` accepts `sda_pin`, `scl_pin`, optional `address`, and optional `frequency_hz`
- it defaults to address `0x23` and also supports `0x5C`
- runtime flow is deterministic in firmware: power on, start one-time high-resolution measurement, wait 180 ms, read 2 bytes, format lux
- raw `i2c_*` tools stay in place; this is the first typed read layer on top

## Validation
- `./scripts/test.sh host`
- `./scripts/build.sh`
- flashed `feat/bh1750-read` onto the attached board and confirmed post-flash serial `status` smoke still works

## Caveat
- I do not have a convincing positive hardware BH1750 read on the attached board. This branch has strong host coverage plus generic board smoke, but not a real BH1750-on-hardware proof on the currently attached setup.
