### PR TITLE
docs: note CMakeLists step for firmware tool creation

### DIFF
--- a/docs-site/build-your-own-tool.html
+++ b/docs-site/build-your-own-tool.html
@@ -135,6 +135,7 @@ Agent: Creates a tool using the remembered lighting pin instead of asking you to
           <p class="inline-note">Example boundary: a user tool can compose <code>i2c_write_read</code> or <code>dht_read</code>, but it cannot invent a new bus or timing-sensitive sensor driver. That belongs in firmware.</p>
           <ol>
             <li>Implement handler logic in <code>main/tools_*.c</code> with signature <code>bool handler(const cJSON *input, char *result, size_t result_len)</code>.</li>
+            <li>If you created a new <code>.c</code> file, add it to the <code>SRCS</code> list in <code>main/CMakeLists.txt</code> so the build picks it up.</li>
             <li>Declare it in <code>main/tools_handlers.h</code>.</li>
             <li>Add one entry in <code>main/builtin_tools.def</code>.</li>
             <li>Add/extend host tests in <code>test/host/</code>.</li>
@@ -161,17 +162,26 @@ bool tools_relay_status_handler(const cJSON *input, char *result, size_t result_
     return true;
 }</pre>
           <ol start="2">
+            <li>Add the new source file to <code>main/CMakeLists.txt</code> (skip if you extended an existing <code>tools_*.c</code>).</li>
+          </ol>
+          <pre>idf_component_register(
+    SRCS
+        ...
+        "tools_relay.c"
+        ...
+)</pre>
+          <ol start="3">
             <li>Declare the handler in <code>main/tools_handlers.h</code>.</li>
           </ol>
           <pre>bool tools_relay_status_handler(const cJSON *input, char *result, size_t result_len);</pre>
-          <ol start="3">
+          <ol start="4">
             <li>Register it in <code>main/builtin_tools.def</code> so the model can discover and call it.</li>
           </ol>
           <pre>TOOL_ENTRY("relay_status",
            "Get relay health from host web relay.",
            "{\"type\":\"object\",\"properties\":{}}",
            tools_relay_status_handler)</pre>
-          <ol start="4">
+          <ol start="5">
             <li>Add host coverage in <code>test/host/</code> for input validation and expected output shape.</li>
             <li>Build and run through the normal firmware flow.</li>
           </ol>

--- a/docs-site/reference/README_COMPLETE.md
+++ b/docs-site/reference/README_COMPLETE.md
@@ -399,13 +399,24 @@ bool tools_relay_status_handler(const cJSON *input, char *result, size_t result_
 }
 ```
 
-2. Declare it in `main/tools_handlers.h`:
+2. Add the new source file to `main/CMakeLists.txt` (skip if you extended an existing `tools_*.c`):
+
+```cmake
+idf_component_register(
+    SRCS
+        ...
+        "tools_relay.c"
+        ...
+)
+```
+
+3. Declare it in `main/tools_handlers.h`:
 
 ```c
 bool tools_relay_status_handler(const cJSON *input, char *result, size_t result_len);
 ```
 
-3. Register it in `main/builtin_tools.def`:
+4. Register it in `main/builtin_tools.def`:
 
 ```c
 TOOL_ENTRY("relay_status",
@@ -414,8 +425,8 @@ TOOL_ENTRY("relay_status",
            tools_relay_status_handler)
 ```
 
-4. Add host tests in `test/host/` for validation and output shape.
-5. Run the normal firmware flow:
+5. Add host tests in `test/host/` for validation and output shape.
+6. Run the normal firmware flow:
 
 ```bash
 ./scripts/test.sh host


### PR DESCRIPTION
## Summary
- Closes #49.
- The Build Your Own Tool docs (Approach 2 / Method B) skipped a required step: when you create a new `main/tools_*.c` source file, you must also add it to the `SRCS` list in `main/CMakeLists.txt` or the build will not pick it up.
- Adds the step to both the overview list and the step-by-step walkthrough in `docs-site/build-your-own-tool.html`, and to the mirror in `docs-site/reference/README_COMPLETE.md`. Wording notes that the step can be skipped when extending an existing `tools_*.c`.

## Test plan
- [ ] Open `docs-site/build-your-own-tool.html` in a browser and confirm the Approach 2 list and Method B walkthrough both mention CMakeLists with renumbered steps.
- [ ] Skim `docs-site/reference/README_COMPLETE.md` Method B section for matching numbering.